### PR TITLE
fix: update Go to 1.24.11 to fix stdlib vulnerabilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.24'
+        go-version: '1.24.11'
         cache: true
 
     - name: Verify formatting

--- a/cmd/thinktank/cli_errors_test.go
+++ b/cmd/thinktank/cli_errors_test.go
@@ -38,7 +38,7 @@ func TestErrorHandlingForPartialFailures(t *testing.T) {
 			mockLogger.errorMessages = nil
 
 			// Create an error with the test case message
-			err := fmt.Errorf(tc.errorMessage)
+			err := fmt.Errorf("%s", tc.errorMessage)
 
 			// Call the same error logging pattern used in main.go
 			mockLogger.Error("Application failed: %v", err)

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/phrazzld/thinktank
 
-go 1.23.0
-
-toolchain go1.23.7
+go 1.24.11
 
 require (
 	github.com/google/uuid v1.6.0

--- a/internal/logutil/buffer_logger.go
+++ b/internal/logutil/buffer_logger.go
@@ -78,7 +78,7 @@ func (l *BufferLogger) Fatal(format string, args ...interface{}) {
 
 // Println implements LoggerInterface by logging at info level
 func (l *BufferLogger) Println(v ...interface{}) {
-	l.Info(fmt.Sprintln(v...))
+	l.Info("%s", fmt.Sprintln(v...))
 }
 
 // Printf implements LoggerInterface by logging at info level

--- a/internal/logutil/logutil.go
+++ b/internal/logutil/logutil.go
@@ -416,7 +416,7 @@ func (l *Logger) GetLevel() LogLevel {
 
 // Println implements LoggerInterface by logging at info level
 func (l *Logger) Println(v ...interface{}) {
-	l.Info(fmt.Sprintln(v...))
+	l.Info("%s", fmt.Sprintln(v...))
 }
 
 // Printf implements LoggerInterface by logging at info level

--- a/internal/logutil/sanitizing_logger_test.go
+++ b/internal/logutil/sanitizing_logger_test.go
@@ -116,35 +116,35 @@ func TestSanitizingLogger(t *testing.T) {
 		{
 			name: "Info with API key",
 			logFunc: func(msg string) {
-				logger.Info(msg)
+				logger.Info("%s", msg)
 			},
 			logMessage: "API key is sk-1234567890abcdef1234567890abcdef1234567890abcdef",
 		},
 		{
 			name: "Error with Bearer token",
 			logFunc: func(msg string) {
-				logger.Error(msg)
+				logger.Error("%s", msg)
 			},
 			logMessage: "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ",
 		},
 		{
 			name: "Debug with URL credentials",
 			logFunc: func(msg string) {
-				logger.Debug(msg)
+				logger.Debug("%s", msg)
 			},
 			logMessage: "Connection string: https://username:password@example.com",
 		},
 		{
 			name: "Warn with password",
 			logFunc: func(msg string) {
-				logger.Warn(msg)
+				logger.Warn("%s", msg)
 			},
 			logMessage: "Password for app is 'supersecretpassword123'",
 		},
 		{
 			name: "InfoContext with API key",
 			logFunc: func(msg string) {
-				logger.InfoContext(ctx, msg)
+				logger.InfoContext(ctx, "%s", msg)
 			},
 			logMessage: "API key is sk-1234567890abcdef1234567890abcdef1234567890abcdef",
 		},

--- a/internal/logutil/secret_detecting_logger_test.go
+++ b/internal/logutil/secret_detecting_logger_test.go
@@ -80,13 +80,13 @@ func TestSecretDetectingLogger(t *testing.T) {
 			// Log the message at the appropriate level
 			switch tc.level {
 			case "Debug":
-				secretLogger.Debug(tc.message)
+				secretLogger.Debug("%s", tc.message)
 			case "Info":
-				secretLogger.Info(tc.message)
+				secretLogger.Info("%s", tc.message)
 			case "Warn":
-				secretLogger.Warn(tc.message)
+				secretLogger.Warn("%s", tc.message)
 			case "Error":
-				secretLogger.Error(tc.message)
+				secretLogger.Error("%s", tc.message)
 			}
 
 			// Check if the message was correctly detected as containing a secret

--- a/internal/logutil/slog_logger.go
+++ b/internal/logutil/slog_logger.go
@@ -373,7 +373,7 @@ func isAttr(arg interface{}) bool {
 func (s *SlogLogger) Println(v ...interface{}) {
 	message := fmt.Sprintln(v...)
 	// Use InfoContext with the logger's context to ensure correlation ID is included
-	s.InfoContext(s.ctx, message)
+	s.InfoContext(s.ctx, "%s", message)
 }
 
 // Printf implements the standard logger interface, logs at INFO level

--- a/internal/logutil/test_logger.go
+++ b/internal/logutil/test_logger.go
@@ -106,7 +106,7 @@ func (l *TestLogger) Fatal(format string, args ...interface{}) {
 
 // Println implements LoggerInterface by logging at info level
 func (l *TestLogger) Println(v ...interface{}) {
-	l.Info(fmt.Sprintln(v...))
+	l.Info("%s", fmt.Sprintln(v...))
 }
 
 // Printf implements LoggerInterface by logging at info level


### PR DESCRIPTION
## Summary
- Update Go version from 1.23.0 to 1.24.11
- Update CI workflow to use Go 1.24.11
- Fix 17 stdlib vulnerabilities in crypto/x509, net/textproto, archive/tar, net/http, encoding/asn1

## Verification
```
$ govulncheck -scan=module
No vulnerabilities found.
```

## Test plan
- [x] `govulncheck` reports no vulnerabilities
- [x] Build passes
- [x] Tests pass
- [ ] CI verification

Closes #116

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain to 1.24.11 for improved stability.

* **Bug Fixes**
  * Hardened logging to use explicit string formatting, preventing accidental format-string interpretation and ensuring safe message output.

* **Tests**
  * Adjusted tests to match the new, format-safe logging usage so test logging reflects production formatting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->