### PR TITLE
refactor: consolidate duplicate type definitions (ContextStats, GatherConfig)

### DIFF
--- a/docs/analysis/DEPENDENCY_INJECTION_ANALYSIS.md
+++ b/docs/analysis/DEPENDENCY_INJECTION_ANALYSIS.md
@@ -85,11 +85,12 @@ func(
 
 ### 4. Adapter Pattern Usage
 
-**Location**: `internal/thinktank/app.go` lines 162-165
+**Location**: `internal/thinktank/app.go`
 
 ```go
 apiServiceAdapter := &APIServiceAdapter{APIService: apiService}
-contextGathererAdapter := &ContextGathererAdapter{ContextGatherer: contextGatherer}
+// Note: ContextGathererAdapter was removed in issue #121 - NewContextGatherer
+// now directly implements interfaces.ContextGatherer
 fileWriterAdapter := &FileWriterAdapter{FileWriter: fileWriter}
 ```
 
@@ -97,6 +98,7 @@ fileWriterAdapter := &FileWriterAdapter{FileWriter: fileWriter}
 - **Interface adaptation**: Converts between interface versions
 - **Composition pattern**: Wraps existing implementations
 - **Dependency bridging**: Connects different package interfaces
+- **Direct implementation**: Where possible, implementations directly satisfy interfaces (preferred)
 
 ## Existing Logger Interface Patterns
 

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/phrazzld/thinktank/internal/models"
 	"github.com/phrazzld/thinktank/internal/ratelimit"
 	"github.com/phrazzld/thinktank/internal/thinktank"
+	"github.com/phrazzld/thinktank/internal/thinktank/interfaces"
 	"github.com/phrazzld/thinktank/internal/thinktank/orchestrator"
 	"github.com/phrazzld/thinktank/internal/version"
 )
@@ -273,7 +274,7 @@ func runApplication(ctx context.Context, cfg *config.MinimalConfig, logger logut
 	// Create orchestrator with adapters for type compatibility
 	orch := orchestrator.NewOrchestrator(
 		apiService,
-		&thinktank.ContextGathererAdapter{ContextGatherer: contextGatherer},
+		contextGatherer, // Now directly implements interfaces.ContextGatherer
 		fileWriter,
 		auditLogger,
 		rateLimiter,
@@ -425,7 +426,7 @@ func runDryRun(ctx context.Context, cfg *config.MinimalConfig, instructions stri
 
 	// Gather context
 	// Create gather config
-	gatherConfig := thinktank.GatherConfig{
+	gatherConfig := interfaces.GatherConfig{
 		Paths:        cfg.TargetPaths,
 		Format:       appConfig.Format,
 		Exclude:      appConfig.Excludes.Extensions,

--- a/internal/thinktank/adapters.go
+++ b/internal/thinktank/adapters.go
@@ -4,7 +4,6 @@ package thinktank
 import (
 	"context"
 
-	"github.com/phrazzld/thinktank/internal/fileutil"
 	"github.com/phrazzld/thinktank/internal/llm"
 	"github.com/phrazzld/thinktank/internal/models"
 	"github.com/phrazzld/thinktank/internal/thinktank/interfaces"
@@ -72,78 +71,8 @@ func (a *APIServiceAdapter) ValidateModelParameter(ctx context.Context, modelNam
 // Note: TokenManagerAdapter was removed as part of T032A
 // to remove token handling from the application.
 
-// ContextGathererAdapter provides an adapter for different ContextGatherer implementations
-// It adapts the internal ContextGatherer interface to the interfaces.ContextGatherer interface
-type ContextGathererAdapter struct {
-	// The underlying ContextGatherer implementation from the internal package
-	ContextGatherer ContextGatherer
-}
-
-// Convert internal GatherConfig to interfaces.GatherConfig
-func internalToInterfacesGatherConfig(config interfaces.GatherConfig) GatherConfig {
-	return GatherConfig{
-		Paths:        config.Paths,
-		Include:      config.Include,
-		Exclude:      config.Exclude,
-		ExcludeNames: config.ExcludeNames,
-		Format:       config.Format,
-		Verbose:      config.Verbose,
-		LogLevel:     config.LogLevel,
-	}
-}
-
-// Convert internal ContextStats to interfaces.ContextStats
-func internalToInterfacesContextStats(stats *ContextStats) *interfaces.ContextStats {
-	if stats == nil {
-		return nil
-	}
-	return &interfaces.ContextStats{
-		ProcessedFilesCount: stats.ProcessedFilesCount,
-		CharCount:           stats.CharCount,
-		LineCount:           stats.LineCount,
-		// TokenCount field removed as part of T032F - token handling refactoring
-		ProcessedFiles: stats.ProcessedFiles,
-	}
-}
-
-// Convert interfaces.ContextStats to internal ContextStats
-func interfacesToInternalContextStats(stats *interfaces.ContextStats) *ContextStats {
-	if stats == nil {
-		return nil
-	}
-	return &ContextStats{
-		ProcessedFilesCount: stats.ProcessedFilesCount,
-		CharCount:           stats.CharCount,
-		LineCount:           stats.LineCount,
-		// TokenCount field removed as part of T032F - token handling refactoring
-		ProcessedFiles: stats.ProcessedFiles,
-	}
-}
-
-// GatherContext adapts between interfaces.GatherConfig and internal GatherConfig
-func (c *ContextGathererAdapter) GatherContext(ctx context.Context, config interfaces.GatherConfig) ([]fileutil.FileMeta, *interfaces.ContextStats, error) {
-	// Convert interfaces.GatherConfig to internal GatherConfig
-	internalConfig := internalToInterfacesGatherConfig(config)
-
-	// Call the underlying internal implementation
-	files, stats, err := c.ContextGatherer.GatherContext(ctx, internalConfig)
-
-	// Convert internal ContextStats to interfaces.ContextStats if no error
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return files, internalToInterfacesContextStats(stats), nil
-}
-
-// DisplayDryRunInfo adapts between interfaces.ContextStats and internal ContextStats
-func (c *ContextGathererAdapter) DisplayDryRunInfo(ctx context.Context, stats *interfaces.ContextStats) error {
-	// Convert interfaces.ContextStats to internal ContextStats
-	internalStats := interfacesToInternalContextStats(stats)
-
-	// Call the underlying internal implementation
-	return c.ContextGatherer.DisplayDryRunInfo(ctx, internalStats)
-}
+// Note: ContextGathererAdapter was removed as part of issue #121
+// ContextStats, GatherConfig, and ContextGatherer are now defined once in interfaces/
 
 // FileWriterAdapter provides an adapter for different FileWriter implementations
 // It adapts the internal FileWriter interface to the interfaces.FileWriter interface

--- a/internal/thinktank/adapters.go
+++ b/internal/thinktank/adapters.go
@@ -68,11 +68,8 @@ func (a *APIServiceAdapter) ValidateModelParameter(ctx context.Context, modelNam
 	return a.APIService.ValidateModelParameter(ctx, modelName, paramName, value)
 }
 
-// Note: TokenManagerAdapter was removed as part of T032A
-// to remove token handling from the application.
-
-// Note: ContextGathererAdapter was removed as part of issue #121
-// ContextStats, GatherConfig, and ContextGatherer are now defined once in interfaces/
+// Note: TokenManagerAdapter and ContextGathererAdapter were removed.
+// Types are now defined once in interfaces/.
 
 // FileWriterAdapter provides an adapter for different FileWriter implementations
 // It adapts the internal FileWriter interface to the interfaces.FileWriter interface

--- a/internal/thinktank/adapters_impl_test.go
+++ b/internal/thinktank/adapters_impl_test.go
@@ -21,9 +21,6 @@ func setupAPIServiceAdapterTest() (*APIServiceAdapter, *MockAPIServiceForAdapter
 	return adapter, mockAPIService
 }
 
-// Note: setupContextGathererAdapterTest was removed as part of issue #121
-// ContextGatherer now directly implements interfaces.ContextGatherer
-
 // setupFileWriterAdapterTest creates test fixtures for FileWriterAdapter testing
 func setupFileWriterAdapterTest() (*FileWriterAdapter, *MockFileWriter) {
 	mockFileWriter := NewMockFileWriter()
@@ -399,13 +396,6 @@ func TestAPIServiceAdapter_GetModelTokenLimits_WithImplementation(t *testing.T) 
 	}
 }
 
-// We're removing TestAPIServiceAdapter_GetModelTokenLimits_WithoutImplementation_KnownModels
-// Since we've refactored the adapter to remove the special type assertions for MockAPIServiceWithoutExtensions,
-// this test is no longer relevant, and the adapter falls back to the implementation in the mock itself
-
-// Note: ContextGathererAdapter tests were removed as part of issue #121
-// ContextGatherer now directly implements interfaces.ContextGatherer
-
 // Tests for FileWriterAdapter
 
 // TestFileWriterAdapter_SaveToFile verifies that SaveToFile calls are properly delegated
@@ -440,8 +430,3 @@ func TestFileWriterAdapter_SaveToFile(t *testing.T) {
 		t.Errorf("Unexpected parameters: Content = %s, OutputFile = %s", call.Content, call.OutputFile)
 	}
 }
-
-// Note: Tests for conversion functions (TestInternalToInterfacesGatherConfig,
-// TestInternalToInterfacesContextStats, TestInterfacesToInternalContextStats) were removed
-// as part of issue #121. These conversion functions are no longer needed since
-// ContextStats, GatherConfig, and ContextGatherer are now defined once in interfaces/.

--- a/internal/thinktank/adapters_impl_test.go
+++ b/internal/thinktank/adapters_impl_test.go
@@ -8,10 +8,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/phrazzld/thinktank/internal/fileutil"
 	"github.com/phrazzld/thinktank/internal/llm"
 	"github.com/phrazzld/thinktank/internal/models"
-	"github.com/phrazzld/thinktank/internal/thinktank/interfaces"
 )
 
 // setupAPIServiceAdapterTest creates test fixtures for APIServiceAdapter testing
@@ -23,14 +21,8 @@ func setupAPIServiceAdapterTest() (*APIServiceAdapter, *MockAPIServiceForAdapter
 	return adapter, mockAPIService
 }
 
-// setupContextGathererAdapterTest creates test fixtures for ContextGathererAdapter testing
-func setupContextGathererAdapterTest() (*ContextGathererAdapter, *MockContextGatherer) {
-	mockContextGatherer := NewMockContextGatherer()
-	adapter := &ContextGathererAdapter{
-		ContextGatherer: mockContextGatherer,
-	}
-	return adapter, mockContextGatherer
-}
+// Note: setupContextGathererAdapterTest was removed as part of issue #121
+// ContextGatherer now directly implements interfaces.ContextGatherer
 
 // setupFileWriterAdapterTest creates test fixtures for FileWriterAdapter testing
 func setupFileWriterAdapterTest() (*FileWriterAdapter, *MockFileWriter) {
@@ -411,131 +403,8 @@ func TestAPIServiceAdapter_GetModelTokenLimits_WithImplementation(t *testing.T) 
 // Since we've refactored the adapter to remove the special type assertions for MockAPIServiceWithoutExtensions,
 // this test is no longer relevant, and the adapter falls back to the implementation in the mock itself
 
-// Tests for ContextGathererAdapter
-
-// TestContextGathererAdapter_GatherContext verifies that GatherContext calls are properly delegated
-func TestContextGathererAdapter_GatherContext(t *testing.T) {
-	adapter, mock := setupContextGathererAdapterTest()
-
-	// Set up expected return values
-	expectedFiles := []fileutil.FileMeta{{Path: "test.go"}}
-	expectedStats := &ContextStats{
-		ProcessedFilesCount: 1,
-		CharCount:           100,
-		LineCount:           10,
-		ProcessedFiles:      []string{"test.go"},
-	}
-	expectedErr := errors.New("test error")
-
-	mock.GatherContextFunc = func(ctx context.Context, config GatherConfig) ([]fileutil.FileMeta, *ContextStats, error) {
-		return expectedFiles, expectedStats, expectedErr
-	}
-
-	// Create a test input
-	ctx := context.Background()
-	config := interfaces.GatherConfig{
-		Paths:        []string{"./testdata"},
-		Include:      "*.go",
-		Exclude:      "vendor/",
-		ExcludeNames: "test_",
-		Format:       "json",
-		Verbose:      true,
-		LogLevel:     1, // Debug level
-	}
-
-	// Call the adapter method
-	files, stats, err := adapter.GatherContext(ctx, config)
-
-	// If there was an expected error, verify it's returned correctly
-	if expectedErr != nil {
-		if err != expectedErr {
-			t.Errorf("Expected error %v, got %v", expectedErr, err)
-		}
-		// When there's an expected error, the other values should be nil
-		if files != nil || stats != nil {
-			t.Errorf("Expected nil results with error, got files=%v, stats=%v", files, stats)
-		}
-		return
-	}
-
-	// Since there's no expected error, verify that no error was returned
-	if err != nil {
-		t.Errorf("Expected no error, got %v", err)
-	}
-
-	// Verify that the adapter delegated the call correctly
-	if !reflect.DeepEqual(files, expectedFiles) {
-		t.Errorf("Expected files %v, got %v", expectedFiles, files)
-	}
-
-	// Verify that the returned stats match the expected stats
-	expectedInterfaceStats := internalToInterfacesContextStats(expectedStats)
-	if !reflect.DeepEqual(stats, expectedInterfaceStats) {
-		t.Errorf("Expected stats %+v, got %+v", expectedInterfaceStats, stats)
-	}
-
-	// Verify that the mock was called with the expected parameters
-	if len(mock.GatherContextCalls) != 1 {
-		t.Fatalf("Expected 1 call to GatherContext, got %d", len(mock.GatherContextCalls))
-	}
-	call := mock.GatherContextCalls[0]
-
-	// Verify the context is passed correctly
-	if call.Ctx != ctx {
-		t.Errorf("Unexpected context: %v", call.Ctx)
-	}
-
-	// Verify that the config was converted correctly
-	expectedInternalConfig := internalToInterfacesGatherConfig(config)
-	if !reflect.DeepEqual(call.Config, expectedInternalConfig) {
-		t.Errorf("Expected config %+v, got %+v", expectedInternalConfig, call.Config)
-	}
-}
-
-// TestContextGathererAdapter_DisplayDryRunInfo verifies that DisplayDryRunInfo calls are properly delegated
-func TestContextGathererAdapter_DisplayDryRunInfo(t *testing.T) {
-	adapter, mock := setupContextGathererAdapterTest()
-
-	// Set up expected return value
-	expectedErr := errors.New("test error")
-	mock.DisplayDryRunInfoFunc = func(ctx context.Context, stats *ContextStats) error {
-		return expectedErr
-	}
-
-	// Create a test input
-	ctx := context.Background()
-	stats := &interfaces.ContextStats{
-		ProcessedFilesCount: 1,
-		CharCount:           100,
-		LineCount:           10,
-		ProcessedFiles:      []string{"test.go"},
-	}
-
-	// Call the adapter method
-	err := adapter.DisplayDryRunInfo(ctx, stats)
-
-	// Verify that the adapter delegated the call correctly
-	if err != expectedErr {
-		t.Errorf("Expected error %v, got %v", expectedErr, err)
-	}
-
-	// Verify that the mock was called with the expected parameters
-	if len(mock.DisplayDryRunInfoCalls) != 1 {
-		t.Fatalf("Expected 1 call to DisplayDryRunInfo, got %d", len(mock.DisplayDryRunInfoCalls))
-	}
-	call := mock.DisplayDryRunInfoCalls[0]
-
-	// Verify the context is passed correctly
-	if call.Ctx != ctx {
-		t.Errorf("Unexpected context: %v", call.Ctx)
-	}
-
-	// Verify that the stats were converted correctly
-	expectedInternalStats := interfacesToInternalContextStats(stats)
-	if !reflect.DeepEqual(call.Stats, expectedInternalStats) {
-		t.Errorf("Expected stats %+v, got %+v", expectedInternalStats, call.Stats)
-	}
-}
+// Note: ContextGathererAdapter tests were removed as part of issue #121
+// ContextGatherer now directly implements interfaces.ContextGatherer
 
 // Tests for FileWriterAdapter
 
@@ -572,108 +441,7 @@ func TestFileWriterAdapter_SaveToFile(t *testing.T) {
 	}
 }
 
-// Tests for conversion functions
-
-// TestInternalToInterfacesGatherConfig verifies the conversion from interfaces.GatherConfig to internal GatherConfig
-func TestInternalToInterfacesGatherConfig(t *testing.T) {
-	input := interfaces.GatherConfig{
-		Paths:        []string{"path1", "path2"},
-		Include:      "*.go",
-		Exclude:      "vendor/",
-		ExcludeNames: "test_",
-		Format:       "json",
-		Verbose:      true,
-		LogLevel:     1, // Debug level
-	}
-
-	result := internalToInterfacesGatherConfig(input)
-
-	// Verify that all fields were copied correctly
-	if !reflect.DeepEqual(result.Paths, input.Paths) {
-		t.Errorf("Expected Paths %v, got %v", input.Paths, result.Paths)
-	}
-	if result.Include != input.Include {
-		t.Errorf("Expected Include %s, got %s", input.Include, result.Include)
-	}
-	if result.Exclude != input.Exclude {
-		t.Errorf("Expected Exclude %s, got %s", input.Exclude, result.Exclude)
-	}
-	if result.ExcludeNames != input.ExcludeNames {
-		t.Errorf("Expected ExcludeNames %s, got %s", input.ExcludeNames, result.ExcludeNames)
-	}
-	if result.Format != input.Format {
-		t.Errorf("Expected Format %s, got %s", input.Format, result.Format)
-	}
-	if result.Verbose != input.Verbose {
-		t.Errorf("Expected Verbose %v, got %v", input.Verbose, result.Verbose)
-	}
-	if result.LogLevel != input.LogLevel {
-		t.Errorf("Expected LogLevel %v, got %v", input.LogLevel, result.LogLevel)
-	}
-}
-
-// TestInternalToInterfacesContextStats verifies the conversion from internal ContextStats to interfaces.ContextStats
-func TestInternalToInterfacesContextStats(t *testing.T) {
-	// Test with non-nil stats
-	input := &ContextStats{
-		ProcessedFilesCount: 10,
-		CharCount:           1000,
-		LineCount:           100,
-		ProcessedFiles:      []string{"file1.go", "file2.go"},
-	}
-
-	result := internalToInterfacesContextStats(input)
-
-	// Verify that all fields were copied correctly
-	if result.ProcessedFilesCount != input.ProcessedFilesCount {
-		t.Errorf("Expected ProcessedFilesCount %d, got %d", input.ProcessedFilesCount, result.ProcessedFilesCount)
-	}
-	if result.CharCount != input.CharCount {
-		t.Errorf("Expected CharCount %d, got %d", input.CharCount, result.CharCount)
-	}
-	if result.LineCount != input.LineCount {
-		t.Errorf("Expected LineCount %d, got %d", input.LineCount, result.LineCount)
-	}
-	if !reflect.DeepEqual(result.ProcessedFiles, input.ProcessedFiles) {
-		t.Errorf("Expected ProcessedFiles %v, got %v", input.ProcessedFiles, result.ProcessedFiles)
-	}
-
-	// Test with nil stats
-	nilResult := internalToInterfacesContextStats(nil)
-	if nilResult != nil {
-		t.Errorf("Expected nil result for nil input, got %v", nilResult)
-	}
-}
-
-// TestInterfacesToInternalContextStats verifies the conversion from interfaces.ContextStats to internal ContextStats
-func TestInterfacesToInternalContextStats(t *testing.T) {
-	// Test with non-nil stats
-	input := &interfaces.ContextStats{
-		ProcessedFilesCount: 10,
-		CharCount:           1000,
-		LineCount:           100,
-		ProcessedFiles:      []string{"file1.go", "file2.go"},
-	}
-
-	result := interfacesToInternalContextStats(input)
-
-	// Verify that all fields were copied correctly
-	if result.ProcessedFilesCount != input.ProcessedFilesCount {
-		t.Errorf("Expected ProcessedFilesCount %d, got %d", input.ProcessedFilesCount, result.ProcessedFilesCount)
-	}
-	if result.CharCount != input.CharCount {
-		t.Errorf("Expected CharCount %d, got %d", input.CharCount, result.CharCount)
-	}
-	if result.LineCount != input.LineCount {
-		t.Errorf("Expected LineCount %d, got %d", input.LineCount, result.LineCount)
-	}
-	if !reflect.DeepEqual(result.ProcessedFiles, input.ProcessedFiles) {
-		t.Errorf("Expected ProcessedFiles %v, got %v", input.ProcessedFiles, result.ProcessedFiles)
-	}
-
-	// Test with nil stats
-	nilResult := interfacesToInternalContextStats(nil)
-	if nilResult != nil {
-		t.Errorf("Expected nil result for nil input, got %v", nilResult)
-	}
-}
+// Note: Tests for conversion functions (TestInternalToInterfacesGatherConfig,
+// TestInternalToInterfacesContextStats, TestInterfacesToInternalContextStats) were removed
+// as part of issue #121. These conversion functions are no longer needed since
+// ContextStats, GatherConfig, and ContextGatherer are now defined once in interfaces/.

--- a/internal/thinktank/adapters_test.go
+++ b/internal/thinktank/adapters_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/phrazzld/thinktank/internal/fileutil"
 	"github.com/phrazzld/thinktank/internal/llm"
-	"github.com/phrazzld/thinktank/internal/logutil"
 	"github.com/phrazzld/thinktank/internal/models"
 	"github.com/phrazzld/thinktank/internal/thinktank/interfaces"
 )
@@ -180,49 +179,6 @@ func (m *MockAPIServiceForAdapter) GetModelTokenLimits(ctx context.Context, mode
 		return m.GetModelTokenLimitsFunc(ctx, modelName)
 	}
 	return 0, 0, errors.New("GetModelTokenLimits not implemented")
-}
-
-// TestTokenResult represents a token count result structure for testing only
-// This replaces the removed production TokenResult
-type TestTokenResult struct {
-	TokenCount   int32
-	InputLimit   int32
-	ExceedsLimit bool
-	LimitError   string
-	Percentage   float64
-}
-
-// MockTokenManagerForAdapter is a testing mock for the TokenManager interface, specifically for adapter tests
-type MockTokenManagerForAdapter struct {
-	CheckTokenLimitFunc       func(ctx context.Context, prompt string) error
-	GetTokenInfoFunc          func(ctx context.Context, prompt string) (*TestTokenResult, error)
-	PromptForConfirmationFunc func(tokenCount int32, threshold int) bool
-}
-
-func (m *MockTokenManagerForAdapter) CheckTokenLimit(ctx context.Context, prompt string) error {
-	if m.CheckTokenLimitFunc != nil {
-		return m.CheckTokenLimitFunc(ctx, prompt)
-	}
-	return errors.New("CheckTokenLimit not implemented")
-}
-
-func (m *MockTokenManagerForAdapter) GetTokenInfo(ctx context.Context, prompt string) (*TestTokenResult, error) {
-	if m.GetTokenInfoFunc != nil {
-		return m.GetTokenInfoFunc(ctx, prompt)
-	}
-	return nil, errors.New("GetTokenInfo not implemented")
-}
-
-func (m *MockTokenManagerForAdapter) PromptForConfirmation(tokenCount int32, threshold int) bool {
-	if m.PromptForConfirmationFunc != nil {
-		return m.PromptForConfirmationFunc(tokenCount, threshold)
-	}
-	return false
-}
-
-// GetAdapterTestLogger returns a logger for adapter tests
-func GetAdapterTestLogger() logutil.LoggerInterface {
-	return logutil.NewLogger(logutil.DebugLevel, nil, "[adapter-test] ")
 }
 
 // MockAPIServiceWithoutExtensions implements the full interfaces.APIService interface

--- a/internal/thinktank/adapters_test.go
+++ b/internal/thinktank/adapters_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/phrazzld/thinktank/internal/llm"
 	"github.com/phrazzld/thinktank/internal/logutil"
 	"github.com/phrazzld/thinktank/internal/models"
+	"github.com/phrazzld/thinktank/internal/thinktank/interfaces"
 )
 
 // MockAPIServiceForAdapter is a testing mock for the APIService interface, specifically for adapter tests
@@ -303,11 +304,11 @@ func NewMockAPIServiceWithoutExtensions() *MockAPIServiceWithoutExtensions {
 	}
 }
 
-// MockContextGatherer implements ContextGatherer for testing
+// MockContextGatherer implements interfaces.ContextGatherer for testing
 type MockContextGatherer struct {
 	// Function fields
-	GatherContextFunc     func(ctx context.Context, config GatherConfig) ([]fileutil.FileMeta, *ContextStats, error)
-	DisplayDryRunInfoFunc func(ctx context.Context, stats *ContextStats) error
+	GatherContextFunc     func(ctx context.Context, config interfaces.GatherConfig) ([]fileutil.FileMeta, *interfaces.ContextStats, error)
+	DisplayDryRunInfoFunc func(ctx context.Context, stats *interfaces.ContextStats) error
 
 	// Call tracking fields
 	GatherContextCalls     []GatherContextCall
@@ -317,16 +318,16 @@ type MockContextGatherer struct {
 // Call record structs
 type GatherContextCall struct {
 	Ctx    context.Context
-	Config GatherConfig
+	Config interfaces.GatherConfig
 }
 
 type DisplayDryRunInfoCall struct {
 	Ctx   context.Context
-	Stats *ContextStats
+	Stats *interfaces.ContextStats
 }
 
 // MockContextGatherer method implementations
-func (m *MockContextGatherer) GatherContext(ctx context.Context, config GatherConfig) ([]fileutil.FileMeta, *ContextStats, error) {
+func (m *MockContextGatherer) GatherContext(ctx context.Context, config interfaces.GatherConfig) ([]fileutil.FileMeta, *interfaces.ContextStats, error) {
 	m.GatherContextCalls = append(m.GatherContextCalls, GatherContextCall{
 		Ctx:    ctx,
 		Config: config,
@@ -334,7 +335,7 @@ func (m *MockContextGatherer) GatherContext(ctx context.Context, config GatherCo
 	return m.GatherContextFunc(ctx, config)
 }
 
-func (m *MockContextGatherer) DisplayDryRunInfo(ctx context.Context, stats *ContextStats) error {
+func (m *MockContextGatherer) DisplayDryRunInfo(ctx context.Context, stats *interfaces.ContextStats) error {
 	m.DisplayDryRunInfoCalls = append(m.DisplayDryRunInfoCalls, DisplayDryRunInfoCall{
 		Ctx:   ctx,
 		Stats: stats,
@@ -345,10 +346,10 @@ func (m *MockContextGatherer) DisplayDryRunInfo(ctx context.Context, stats *Cont
 // NewMockContextGatherer creates a new MockContextGatherer with default implementations
 func NewMockContextGatherer() *MockContextGatherer {
 	return &MockContextGatherer{
-		GatherContextFunc: func(ctx context.Context, config GatherConfig) ([]fileutil.FileMeta, *ContextStats, error) {
+		GatherContextFunc: func(ctx context.Context, config interfaces.GatherConfig) ([]fileutil.FileMeta, *interfaces.ContextStats, error) {
 			return nil, nil, nil
 		},
-		DisplayDryRunInfoFunc: func(ctx context.Context, stats *ContextStats) error {
+		DisplayDryRunInfoFunc: func(ctx context.Context, stats *interfaces.ContextStats) error {
 			return nil
 		},
 	}

--- a/internal/thinktank/app.go
+++ b/internal/thinktank/app.go
@@ -179,7 +179,6 @@ func generateOutput(
 
 	// Create adapters for the interfaces
 	apiServiceAdapter := &APIServiceAdapter{APIService: apiService}
-	contextGathererAdapter := &ContextGathererAdapter{ContextGatherer: contextGatherer}
 	fileWriterAdapter := &FileWriterAdapter{FileWriter: fileWriter}
 
 	// Create token counting service for orchestrator
@@ -188,7 +187,7 @@ func generateOutput(
 
 	orch := orchestratorConstructor(
 		apiServiceAdapter,
-		contextGathererAdapter,
+		contextGatherer, // Now directly implements interfaces.ContextGatherer
 		fileWriterAdapter,
 		auditLogger,
 		rateLimiter,

--- a/internal/thinktank/context.go
+++ b/internal/thinktank/context.go
@@ -11,38 +11,10 @@ import (
 	"github.com/phrazzld/thinktank/internal/fileutil"
 	"github.com/phrazzld/thinktank/internal/llm"
 	"github.com/phrazzld/thinktank/internal/logutil"
+	"github.com/phrazzld/thinktank/internal/thinktank/interfaces"
 )
 
-// ContextStats holds information about processed files and context size
-type ContextStats struct {
-	ProcessedFilesCount int
-	CharCount           int
-	LineCount           int
-	// TokenCount field removed as part of T032F - token handling refactoring
-	ProcessedFiles []string
-}
-
-// GatherConfig holds parameters needed for gathering context
-type GatherConfig struct {
-	Paths        []string
-	Include      string
-	Exclude      string
-	ExcludeNames string
-	Format       string
-	Verbose      bool
-	LogLevel     logutil.LogLevel
-}
-
-// ContextGatherer defines the interface for gathering project context
-type ContextGatherer interface {
-	// GatherContext collects and processes files based on configuration
-	GatherContext(ctx context.Context, config GatherConfig) ([]fileutil.FileMeta, *ContextStats, error)
-
-	// DisplayDryRunInfo shows detailed information for dry run mode
-	DisplayDryRunInfo(ctx context.Context, stats *ContextStats) error
-}
-
-// contextGatherer implements the ContextGatherer interface
+// contextGatherer implements the interfaces.ContextGatherer interface
 type contextGatherer struct {
 	logger        logutil.LoggerInterface
 	consoleWriter logutil.ConsoleWriter
@@ -51,8 +23,8 @@ type contextGatherer struct {
 	auditLogger   auditlog.AuditLogger
 }
 
-// NewContextGatherer creates a new ContextGatherer instance
-func NewContextGatherer(logger logutil.LoggerInterface, consoleWriter logutil.ConsoleWriter, dryRun bool, client llm.LLMClient, auditLogger auditlog.AuditLogger) ContextGatherer {
+// NewContextGatherer creates a new interfaces.ContextGatherer instance
+func NewContextGatherer(logger logutil.LoggerInterface, consoleWriter logutil.ConsoleWriter, dryRun bool, client llm.LLMClient, auditLogger auditlog.AuditLogger) interfaces.ContextGatherer {
 	return &contextGatherer{
 		logger:        logger,
 		consoleWriter: consoleWriter,
@@ -65,7 +37,7 @@ func NewContextGatherer(logger logutil.LoggerInterface, consoleWriter logutil.Co
 // Token counting functions removed as part of T032F - token handling refactoring
 
 // GatherContext collects and processes files based on configuration
-func (cg *contextGatherer) GatherContext(ctx context.Context, config GatherConfig) ([]fileutil.FileMeta, *ContextStats, error) {
+func (cg *contextGatherer) GatherContext(ctx context.Context, config interfaces.GatherConfig) ([]fileutil.FileMeta, *interfaces.ContextStats, error) {
 	// Log start of context gathering operation to audit log
 	gatherStartTime := time.Now()
 	inputs := map[string]interface{}{
@@ -98,7 +70,7 @@ func (cg *contextGatherer) GatherContext(ctx context.Context, config GatherConfi
 	fileConfig := fileutil.NewConfig(config.Verbose, config.Include, config.Exclude, config.ExcludeNames, config.Format, cg.logger)
 
 	// Initialize ContextStats
-	stats := &ContextStats{
+	stats := &interfaces.ContextStats{
 		ProcessedFiles: make([]string, 0),
 	}
 
@@ -197,7 +169,7 @@ func (cg *contextGatherer) GatherContext(ctx context.Context, config GatherConfi
 }
 
 // DisplayDryRunInfo shows detailed information for dry run mode
-func (cg *contextGatherer) DisplayDryRunInfo(ctx context.Context, stats *ContextStats) error {
+func (cg *contextGatherer) DisplayDryRunInfo(ctx context.Context, stats *interfaces.ContextStats) error {
 	// Log detailed information to structured logs for debugging
 	cg.logger.InfoContext(ctx, "Dry run mode: displaying context information")
 	cg.logger.DebugContext(ctx, "Found %d files matching filters", stats.ProcessedFilesCount)

--- a/internal/thinktank/context.go
+++ b/internal/thinktank/context.go
@@ -34,8 +34,6 @@ func NewContextGatherer(logger logutil.LoggerInterface, consoleWriter logutil.Co
 	}
 }
 
-// Token counting functions removed as part of T032F - token handling refactoring
-
 // GatherContext collects and processes files based on configuration
 func (cg *contextGatherer) GatherContext(ctx context.Context, config interfaces.GatherConfig) ([]fileutil.FileMeta, *interfaces.ContextStats, error) {
 	// Log start of context gathering operation to audit log
@@ -127,19 +125,15 @@ func (cg *contextGatherer) GatherContext(ctx context.Context, config interfaces.
 	cg.logger.InfoContext(ctx, "Calculating statistics for %d processed files...", stats.ProcessedFilesCount)
 	startTime := time.Now()
 
-	// Calculate character and line counts directly
+	// Calculate character and line counts
 	charCount := len(projectContext)
 	lineCount := strings.Count(projectContext, "\n") + 1
-
-	// Token counting code removed as part of T032F - token handling refactoring
 
 	duration := time.Since(startTime)
 	cg.logger.DebugContext(ctx, "Statistics calculation completed in %v", duration)
 
-	// Store statistics in the stats struct
 	stats.CharCount = charCount
 	stats.LineCount = lineCount
-	// TokenCount field removed as part of T032F - token handling refactoring
 
 	// Handle output based on mode
 	if processedFilesCount > 0 {
@@ -153,13 +147,12 @@ func (cg *contextGatherer) GatherContext(ctx context.Context, config interfaces.
 		}
 	}
 
-	// Log the successful completion of context gathering to audit log
+	// Log successful completion to audit log
 	outputs := map[string]interface{}{
 		"processed_files_count": stats.ProcessedFilesCount,
 		"char_count":            stats.CharCount,
 		"line_count":            stats.LineCount,
-		// token_count field removed as part of T032F - token handling refactoring
-		"files_count": len(contextFiles),
+		"files_count":           len(contextFiles),
 	}
 	if logErr := cg.auditLogger.LogOp(ctx, "GatherContext", "Success", inputs, outputs, nil); logErr != nil {
 		cg.logger.ErrorContext(ctx, "Failed to write audit log: %v", logErr)
@@ -200,9 +193,6 @@ func (cg *contextGatherer) DisplayDryRunInfo(ctx context.Context, stats *interfa
 	cg.consoleWriter.StatusMessage(fmt.Sprintf("  Files: %d", stats.ProcessedFilesCount))
 	cg.consoleWriter.StatusMessage(fmt.Sprintf("  Lines: %d", stats.LineCount))
 	cg.consoleWriter.StatusMessage(fmt.Sprintf("  Characters: %d", stats.CharCount))
-
-	// Token counting and limit comparison code removed as part of T032F - token handling refactoring
-
 	cg.consoleWriter.StatusMessage("")
 	cg.consoleWriter.SuccessMessage("Dry run completed successfully.")
 	cg.consoleWriter.StatusMessage("To generate content, run without the --dry-run flag.")

--- a/internal/thinktank/context_test.go
+++ b/internal/thinktank/context_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/phrazzld/thinktank/internal/llm"
 	"github.com/phrazzld/thinktank/internal/logutil"
 	"github.com/phrazzld/thinktank/internal/testutil"
+	"github.com/phrazzld/thinktank/internal/thinktank/interfaces"
 )
 
 // mockConsoleWriter is a simple mock implementation of ConsoleWriter for testing
@@ -63,7 +64,7 @@ func TestGatherContext(t *testing.T) {
 	tests := []struct {
 		name           string
 		setupFiles     map[string][]byte
-		config         GatherConfig
+		config         interfaces.GatherConfig
 		dryRun         bool
 		expectError    bool
 		expectFiles    int
@@ -76,7 +77,7 @@ func TestGatherContext(t *testing.T) {
 				"config.go": []byte("package main\n\ntype Config struct {\n\tValue string\n}"),
 				"README.md": []byte("# Project\n\nThis is a test project."),
 			},
-			config: GatherConfig{
+			config: interfaces.GatherConfig{
 				Paths:        []string{}, // Will be set to temp dir
 				Include:      "",
 				Exclude:      "",
@@ -96,7 +97,7 @@ func TestGatherContext(t *testing.T) {
 				"test.go":   []byte("package test"),
 				"helper.go": []byte("package test\n\nfunc Helper() {}"),
 			},
-			config: GatherConfig{
+			config: interfaces.GatherConfig{
 				Paths:        []string{}, // Will be set to temp dir
 				Include:      ".go",
 				Exclude:      "",
@@ -113,7 +114,7 @@ func TestGatherContext(t *testing.T) {
 		{
 			name:       "empty directory",
 			setupFiles: map[string][]byte{},
-			config: GatherConfig{
+			config: interfaces.GatherConfig{
 				Paths:        []string{}, // Will be set to temp dir
 				Include:      "",
 				Exclude:      "",
@@ -134,7 +135,7 @@ func TestGatherContext(t *testing.T) {
 				"test.txt":    []byte("test content"),
 				"config.json": []byte(`{"test": true}`),
 			},
-			config: GatherConfig{
+			config: interfaces.GatherConfig{
 				Paths:        []string{}, // Will be set to temp dir
 				Include:      "",
 				Exclude:      ".txt,.json",
@@ -281,12 +282,12 @@ func TestGatherContext(t *testing.T) {
 func TestDisplayDryRunInfo(t *testing.T) {
 	tests := []struct {
 		name                string
-		stats               *ContextStats
+		stats               *interfaces.ContextStats
 		expectedLogMessages []string
 	}{
 		{
 			name: "display info with multiple files",
-			stats: &ContextStats{
+			stats: &interfaces.ContextStats{
 				ProcessedFilesCount: 3,
 				CharCount:           150,
 				LineCount:           25,
@@ -308,7 +309,7 @@ func TestDisplayDryRunInfo(t *testing.T) {
 		},
 		{
 			name: "display info with no files",
-			stats: &ContextStats{
+			stats: &interfaces.ContextStats{
 				ProcessedFilesCount: 0,
 				CharCount:           0,
 				LineCount:           0,
@@ -327,7 +328,7 @@ func TestDisplayDryRunInfo(t *testing.T) {
 		},
 		{
 			name: "display info with single file",
-			stats: &ContextStats{
+			stats: &interfaces.ContextStats{
 				ProcessedFilesCount: 1,
 				CharCount:           42,
 				LineCount:           3,
@@ -410,7 +411,7 @@ func TestGatherContext_AuditLogging(t *testing.T) {
 	gatherer := NewContextGatherer(mockLogger, mockConsoleWriter, false, mockClient, mockLogger)
 
 	// Create config
-	config := GatherConfig{
+	config := interfaces.GatherConfig{
 		Paths:        []string{tempDir},
 		Include:      "",
 		Exclude:      "",
@@ -514,5 +515,5 @@ func TestNewContextGatherer(t *testing.T) {
 	}
 
 	// Verify the gatherer implements the interface
-	var _ = ContextGatherer(gatherer)
+	var _ interfaces.ContextGatherer = gatherer
 }

--- a/internal/thinktank/context_test.go
+++ b/internal/thinktank/context_test.go
@@ -514,6 +514,6 @@ func TestNewContextGatherer(t *testing.T) {
 		t.Fatal("NewContextGatherer should not return nil")
 	}
 
-	// Verify the gatherer implements the interface
-	var _ interfaces.ContextGatherer = gatherer
+	// Verify the gatherer implements the interface (compile-time check)
+	_ = (interfaces.ContextGatherer)(gatherer)
 }

--- a/internal/thinktank/interfaces/interfaces.go
+++ b/internal/thinktank/interfaces/interfaces.go
@@ -103,8 +103,7 @@ type ContextStats struct {
 	ProcessedFilesCount int
 	CharCount           int
 	LineCount           int
-	// TokenCount field removed as part of T032F - token handling refactoring
-	ProcessedFiles []string
+	ProcessedFiles      []string
 }
 
 // GatherConfig holds parameters needed for gathering context


### PR DESCRIPTION
## Summary
- Remove duplicate `ContextStats`, `GatherConfig`, and `ContextGatherer` type definitions
- Eliminate `ContextGathererAdapter` - `NewContextGatherer` now directly implements `interfaces.ContextGatherer`
- Clean up stale comments and dead test code

## Changes
| File | Change |
|------|--------|
| `context.go` | Use `interfaces.*` types directly, remove duplicate definitions |
| `adapters.go` | Remove `ContextGathererAdapter` and conversion functions (~70 LOC) |
| `app.go`, `main.go` | Use `NewContextGatherer` directly without adapter wrapping |
| Test files | Update to use `interfaces.*` types, remove adapter tests |
| `interfaces/interfaces.go` | Remove stale TokenCount comment |

## Impact
- **-450 lines** net code reduction
- **3 types** consolidated from 2 definitions each to 1
- **83.2% test coverage** maintained (above 79% threshold)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/thinktank/...` passes
- [x] Pre-commit hooks pass
- [x] Pre-push checks pass

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified context gathering architecture by removing intermediate adapter layer; components now use direct interface implementations.
  * Removed token count field from context statistics.

* **Tests**
  * Updated test mocks and fixtures to align with refactored interface structure.

* **Documentation**
  * Updated architecture analysis documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->