### PR TITLE
feat(ci): add automatic PR size labeling workflow

### DIFF
--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -1,0 +1,28 @@
+name: PR Size Labeler
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  size-label:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: codelytv/pr-size-labeler@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          xs_label: 'size/XS'
+          xs_max_size: 10
+          s_label: 'size/S'
+          s_max_size: 100
+          m_label: 'size/M'
+          m_max_size: 200
+          l_label: 'size/L'
+          l_max_size: 400
+          xl_label: 'size/XL'
+          fail_if_xl: false
+          message_if_xl: >
+            This PR exceeds 400 lines. Consider splitting into smaller,
+            more reviewable chunks if possible.


### PR DESCRIPTION
## Summary
- Add GitHub Action to auto-label PRs by size (XS/S/M/L/XL)
- Adds gentle reminder for XL PRs (>400 lines) to encourage splitting

## Size thresholds
| Label | Max Lines |
|-------|-----------|
| XS | 10 |
| S | 100 |
| M | 200 |
| L | 400 |
| XL | 400+ |

## Benefits
- Zero cost (GitHub-hosted action)
- Enables `gh pr list --label "size/XL"` for review triage
- Encourages smaller, reviewable PRs

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated pull request size labeling. PRs are now automatically assigned size labels (XS, S, M, L, XL) based on the number of lines changed, with thresholds ranging from 0–10 lines (XS) to over 400 lines (XL). This helps maintain review efficiency and code quality standards.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->