### PR TITLE
fix(ux): sanitize display paths to prevent absolute path leaks

### DIFF
--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/phrazzld/thinktank/internal/llm"
 	"github.com/phrazzld/thinktank/internal/logutil"
 	"github.com/phrazzld/thinktank/internal/models"
+	"github.com/phrazzld/thinktank/internal/pathutil"
 	"github.com/phrazzld/thinktank/internal/ratelimit"
 	"github.com/phrazzld/thinktank/internal/thinktank"
 	"github.com/phrazzld/thinktank/internal/thinktank/interfaces"
@@ -381,7 +382,7 @@ func runDryRun(ctx context.Context, cfg *config.MinimalConfig, instructions stri
 		fmt.Printf("Instructions file: %s\n", cfg.InstructionsFile)
 		fmt.Printf("Target paths: %v\n", cfg.TargetPaths)
 		fmt.Printf("Models: %v\n", cfg.ModelNames)
-		fmt.Printf("Output directory: %s\n", cfg.OutputDir)
+		fmt.Printf("Output directory: %s\n", pathutil.SanitizePathForDisplay(cfg.OutputDir))
 
 		// Show tokenizer status as requested in TODO Phase 6.1
 		availableProviders := models.GetAvailableProviders()

--- a/internal/logutil/console_writer.go
+++ b/internal/logutil/console_writer.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/phrazzld/thinktank/internal/pathutil"
 	"golang.org/x/term"
 )
 
@@ -790,10 +791,10 @@ func (c *consoleWriter) ShowSummarySection(summary SummaryData) {
 			statusText)
 	}
 
-	// Show output directory
+	// Show output directory (sanitized to prevent leaking absolute paths)
 	WriteToConsoleF("%s Output directory: %s\n",
 		c.colors.ColorSymbol(c.symbols.GetSymbols().Bullet),
-		c.colors.ColorFilePath(summary.OutputDirectory))
+		c.colors.ColorFilePath(pathutil.SanitizePathForDisplay(summary.OutputDirectory)))
 
 	// Add contextual messaging and guidance based on scenarios
 	c.displayScenarioGuidance(summary)

--- a/internal/logutil/console_writer_modern_test.go
+++ b/internal/logutil/console_writer_modern_test.go
@@ -277,10 +277,10 @@ func TestModernConsoleWriter_SummaryFormatting(t *testing.T) {
 		"───────",              // Separator line
 		"* 4 models processed", // ASCII bullet point with stats
 		"* 3 successful, 1 failed",
-		"* Synthesis: [OK] completed", // ASCII success symbol
-		"* Output directory: /tmp/thinktank-output",
-		"[!] Partial success", // ASCII warning symbol for partial success
-		"* Success rate: 75%", // Success rate calculation
+		"* Synthesis: [OK] completed",            // ASCII success symbol
+		"* Output directory: ./thinktank-output", // Sanitized to relative path
+		"[!] Partial success",                    // ASCII warning symbol for partial success
+		"* Success rate: 75%",                    // Success rate calculation
 	}
 
 	for _, element := range expectedElements {

--- a/internal/pathutil/display.go
+++ b/internal/pathutil/display.go
@@ -1,0 +1,66 @@
+// Package pathutil provides utilities for path manipulation and display.
+package pathutil
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// SanitizePathForDisplay converts an absolute path to a user-friendly
+// relative path for display purposes. This prevents leaking internal
+// build paths or developer machine paths to end users.
+//
+// Behavior:
+//   - If path is within cwd, returns relative path (e.g., "./output")
+//   - If path equals cwd, returns "."
+//   - If path is outside cwd, returns "./" + base directory name
+//   - If path is empty, returns empty string
+//   - On any error, returns the original path unchanged
+func SanitizePathForDisplay(absPath string) string {
+	if absPath == "" {
+		return ""
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return absPath
+	}
+
+	return sanitizePathWithCwd(absPath, cwd)
+}
+
+// sanitizePathWithCwd is the testable core logic that accepts cwd as parameter.
+func sanitizePathWithCwd(absPath, cwd string) string {
+	if absPath == "" {
+		return ""
+	}
+
+	// Clean both paths for consistent comparison
+	absPath = filepath.Clean(absPath)
+	cwd = filepath.Clean(cwd)
+
+	// If path equals cwd, return "."
+	if absPath == cwd {
+		return "."
+	}
+
+	// Try to make relative to cwd
+	relPath, err := filepath.Rel(cwd, absPath)
+	if err != nil {
+		// Can't make relative, return base name prefixed with ./
+		return "./" + filepath.Base(absPath)
+	}
+
+	// Check if the relative path escapes cwd (starts with ..)
+	if strings.HasPrefix(relPath, "..") {
+		// Path is outside cwd, just show base directory name
+		return "./" + filepath.Base(absPath)
+	}
+
+	// Return relative path, ensuring it starts with ./
+	if !strings.HasPrefix(relPath, ".") {
+		return "./" + relPath
+	}
+	return relPath
+}

--- a/internal/pathutil/display_test.go
+++ b/internal/pathutil/display_test.go
@@ -1,0 +1,152 @@
+package pathutil
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestSanitizePathWithCwd(t *testing.T) {
+	// Use a consistent fake cwd for testing
+	fakeCwd := "/home/user/project"
+
+	tests := []struct {
+		name     string
+		absPath  string
+		cwd      string
+		expected string
+	}{
+		{
+			name:     "empty path",
+			absPath:  "",
+			cwd:      fakeCwd,
+			expected: "",
+		},
+		{
+			name:     "path equals cwd",
+			absPath:  "/home/user/project",
+			cwd:      fakeCwd,
+			expected: ".",
+		},
+		{
+			name:     "path within cwd",
+			absPath:  "/home/user/project/output",
+			cwd:      fakeCwd,
+			expected: "./output",
+		},
+		{
+			name:     "nested path within cwd",
+			absPath:  "/home/user/project/output/subdir/file.txt",
+			cwd:      fakeCwd,
+			expected: "./output/subdir/file.txt",
+		},
+		{
+			name:     "path outside cwd - sibling",
+			absPath:  "/home/user/other-project/output",
+			cwd:      fakeCwd,
+			expected: "./output",
+		},
+		{
+			name:     "path outside cwd - parent",
+			absPath:  "/home/user",
+			cwd:      fakeCwd,
+			expected: "./user",
+		},
+		{
+			name:     "path outside cwd - different tree",
+			absPath:  "/var/log/app.log",
+			cwd:      fakeCwd,
+			expected: "./app.log",
+		},
+		{
+			name:     "path with trailing slash",
+			absPath:  "/home/user/project/output/",
+			cwd:      fakeCwd,
+			expected: "./output",
+		},
+		{
+			name:     "path with redundant components",
+			absPath:  "/home/user/project/./output/../output",
+			cwd:      fakeCwd,
+			expected: "./output",
+		},
+		{
+			name:     "cwd with trailing slash",
+			absPath:  "/home/user/project/output",
+			cwd:      "/home/user/project/",
+			expected: "./output",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := sanitizePathWithCwd(tc.absPath, tc.cwd)
+			if result != tc.expected {
+				t.Errorf("sanitizePathWithCwd(%q, %q) = %q; want %q",
+					tc.absPath, tc.cwd, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestSanitizePathWithCwdWindows(t *testing.T) {
+	// Test Windows-style paths (will work on all platforms via filepath.Clean)
+	if filepath.Separator != '\\' {
+		t.Skip("Skipping Windows path tests on non-Windows platform")
+	}
+
+	tests := []struct {
+		name     string
+		absPath  string
+		cwd      string
+		expected string
+	}{
+		{
+			name:     "windows path within cwd",
+			absPath:  `C:\Users\dev\project\output`,
+			cwd:      `C:\Users\dev\project`,
+			expected: `.\output`,
+		},
+		{
+			name:     "windows path outside cwd",
+			absPath:  `D:\other\path`,
+			cwd:      `C:\Users\dev\project`,
+			expected: `.\path`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := sanitizePathWithCwd(tc.absPath, tc.cwd)
+			if result != tc.expected {
+				t.Errorf("sanitizePathWithCwd(%q, %q) = %q; want %q",
+					tc.absPath, tc.cwd, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestSanitizePathForDisplay_Integration(t *testing.T) {
+	// This test verifies the function works with actual os.Getwd()
+	// It's more of an integration test to ensure the function doesn't panic
+
+	tests := []struct {
+		name    string
+		absPath string
+	}{
+		{"empty", ""},
+		{"relative already", "output"},
+		{"absolute temp", "/tmp/test"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Should not panic
+			result := SanitizePathForDisplay(tc.absPath)
+
+			// Empty input should return empty output
+			if tc.absPath == "" && result != "" {
+				t.Errorf("SanitizePathForDisplay(%q) = %q; want empty", tc.absPath, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add `pathutil.SanitizePathForDisplay()` to convert absolute paths to relative paths in user-facing output
- Prevents information disclosure of developer machine paths (e.g., `/Users/phaedrus/Development/...`)
- Output now shows `./thinktank_...` instead of full absolute paths

## Test plan
- [x] Unit tests for `pathutil` package (90% coverage)
- [x] Updated test expectations in `console_writer_modern_test.go`
- [x] Manual verification: `go run cmd/thinktank/main.go --dry-run README.md .` shows relative paths
- [x] All existing tests pass

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized path sanitization logic for display. Output directory paths in CLI output and summary sections now display in user-friendly relative format (e.g., "./output") instead of absolute system paths, improving readability while protecting internal path details.

* **Tests**
  * Added comprehensive tests for path display sanitization covering edge cases and platform-specific scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->