### PR TITLE
feat(security): add govulncheck to CI security job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,15 @@ jobs:
     needs: test
     steps:
     - uses: actions/checkout@v4
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.24.11'
+        cache: true
+    - name: Install govulncheck
+      run: go install golang.org/x/vuln/cmd/govulncheck@latest
+    - name: Run govulncheck
+      run: govulncheck -scan=module
     - name: Run Trivy security scan
       uses: aquasecurity/trivy-action@0.33.1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
-        go-version: '1.24.11'
+        go-version: '1.24.12'
         cache: true
 
     - name: Verify formatting
@@ -53,9 +53,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
-        go-version: '1.24.11'
+        go-version: '1.24.12'
         cache: true
     - name: Install govulncheck
       run: go install golang.org/x/vuln/cmd/govulncheck@latest


### PR DESCRIPTION
## Summary
Adds Go vulnerability scanning via govulncheck alongside existing Trivy filesystem scanning in CI.

## Changes
- Added Go setup step to security job
- Added govulncheck installation and execution before Trivy
- Security job now has defense-in-depth:
  - **govulncheck**: Go-specific vulnerability database
  - **Trivy**: Broader supply chain vulnerability detection

## Test plan
- [ ] CI passes on this PR
- [ ] Security job runs successfully on main after merge
- [ ] govulncheck exits non-zero if vulnerabilities found (existing behavior)

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded the Go setup used in CI to a newer patch release for tests.
  * Added an additional Go vulnerability check to the security workflow (runs before the existing container scan) and enabled caching to speed CI.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->