### PR TITLE
docs(cli): add exit codes to help output

### DIFF
--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -137,12 +137,12 @@ TROUBLESHOOTING:
 EXIT CODES:
     0    Success - operation completed successfully
     1    Generic error - unexpected failure
-    2    Authentication error - invalid or missing API key
+    2    Authentication error - API rejected credentials
     3    Rate limit error - API rate limit exceeded
-    4    Invalid request - malformed arguments or invalid configuration
+    4    Invalid request - missing required arguments, invalid configuration, or validation failure
     5    Server error - API server returned an error
     6    Network error - connection failed or timed out
-    7    Input error - invalid instructions or target paths
+    7    Input error - content exceeds model context limits
     8    Content filtered - response blocked by safety filters
     9    Insufficient credits - API quota exceeded
     10   Cancelled - operation interrupted by user

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -134,6 +134,19 @@ TROUBLESHOOTING:
         Consider analyzing specific subdirectories or using a model
         with a larger context window (gpt-5.2, gemini-3-flash).
 
+EXIT CODES:
+    0    Success - operation completed successfully
+    1    Generic error - unexpected failure
+    2    Authentication error - invalid or missing API key
+    3    Rate limit error - API rate limit exceeded
+    4    Invalid request - malformed arguments or invalid configuration
+    5    Server error - API server returned an error
+    6    Network error - connection failed or timed out
+    7    Input error - invalid instructions or target paths
+    8    Content filtered - response blocked by safety filters
+    9    Insufficient credits - API quota exceeded
+    10   Cancelled - operation interrupted by user
+
 MORE INFORMATION:
     Documentation: https://github.com/phrazzld/thinktank
     Report issues: https://github.com/phrazzld/thinktank/issues


### PR DESCRIPTION
## Summary
Adds EXIT CODES section to `--help` output, documenting all possible return values.

## Exit Codes Added
| Code | Name | Description |
|------|------|-------------|
| 0 | Success | Operation completed successfully |
| 1 | Generic error | Unexpected failure |
| 2 | Authentication error | Invalid or missing API key |
| 3 | Rate limit error | API rate limit exceeded |
| 4 | Invalid request | Malformed arguments or invalid configuration |
| 5 | Server error | API server returned an error |
| 6 | Network error | Connection failed or timed out |
| 7 | Input error | Invalid instructions or target paths |
| 8 | Content filtered | Response blocked by safety filters |
| 9 | Insufficient credits | API quota exceeded |
| 10 | Cancelled | Operation interrupted by user |

## Impact
- Enables scripting and CI/CD integration
- Professional CLI behavior
- Exit code semantics discoverable via `--help`

## Test plan
- [x] `go build ./...` passes
- [x] Pre-commit hooks pass
- [ ] `thinktank --help` shows EXIT CODES section

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced help section with EXIT CODES reference (0–10) for troubleshooting
  * Added MORE INFORMATION subsection directing users to additional resources

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->