### PR TITLE
feat(cli): add memorable output directory names

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/misty-step/thinktank
 
-go 1.24
+go 1.24.2
 
 require (
 	github.com/charmbracelet/lipgloss v0.10.0

--- a/internal/cli/output_manager_test.go
+++ b/internal/cli/output_manager_test.go
@@ -207,7 +207,11 @@ func TestCreateOutputDirectory(t *testing.T) {
 		tempDir := t.TempDir()
 		err = os.Chdir(tempDir)
 		require.NoError(t, err)
-		defer func() { _ = os.Chdir(originalCwd) }()
+		t.Cleanup(func() {
+			if err := os.Chdir(originalCwd); err != nil {
+				t.Logf("Warning: failed to restore working directory: %v", err)
+			}
+		})
 
 		dirPath, err := om.CreateOutputDirectory("", 0755)
 		require.NoError(t, err)


### PR DESCRIPTION
## Summary
- Replace verbose timestamp-based names (`thinktank_20260128_090818_000936001`) with memorable three-word names like `silver-dancing-oak`
- Use local dictionary approach (no LLM calls) for simplicity, speed, and offline support
- Add collision detection with automatic retry, falling back to timestamp format after 10 attempts
- Update cleanup/stats to recognize both naming formats for backward compatibility

## Implementation Details
- Added word lists: 56 adjectives, 61 verbs (gerund form), 57 nouns
- Total unique combinations: ~195,000 names
- Uses deterministic-but-randomized sequencing (coprime stride) for uniqueness within a session
- Names are 20-40 characters, lowercase, hyphen-separated

## Test plan
- [x] Format validation (adjective-verb-noun pattern)
- [x] Uniqueness validation (100 names, no duplicates)
- [x] Collision handling (retry on existing dirs)
- [x] Fallback to timestamp after max attempts
- [x] Backward compatibility (cleanup recognizes both formats)
- [x] Full test suite passes with race detector

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Default output directories now use memorable, human-readable three-word hyphenated names with collision-aware generation and automatic timestamp fallback; directory retention/cleanup and size/stats reporting added.

* **Chores**
  * Updated Go language version to 1.24.2.

* **Tests**
  * Added tests for memorable-name format, uniqueness, concurrency-safety, retry/collision handling, and fallback behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->