### PR TITLE
chore: align CI Go version with go.mod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24.12'
+        go-version-file: go.mod
         cache: true
 
     - name: Verify formatting
@@ -55,7 +55,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24.12'
+        go-version-file: go.mod
         cache: true
     - name: Install govulncheck
       run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/misty-step/thinktank
 
-go 1.24.2
+go 1.24
+
+toolchain go1.24.2
 
 require (
 	github.com/charmbracelet/lipgloss v0.10.0


### PR DESCRIPTION
## Summary
- Fix `go.mod` to use correct Go directive format (`go 1.24` not `go 1.24.2`)
- Add `toolchain go1.24.2` directive to specify exact toolchain version
- Update CI workflow to use `go-version-file: go.mod` instead of hardcoding `1.24.12`, matching what `release.yml` already does

## Why
The Go directive only accepts major.minor format, not patch versions. This was causing linter/IDE warnings. Hardcoding Go version in CI creates drift when `go.mod` is updated.

## Test plan
- [x] `go build ./...` succeeds
- [x] Quick tests pass (`go test -race -short ./internal/config ./internal/models ./internal/fileutil`)
- [x] Pre-commit hooks pass
- [x] Pre-push hooks pass

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go version configuration and streamlined CI workflow to derive version settings from the project configuration file.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->