### PR TITLE
perf(openrouter): add HTTP connection pooling

### DIFF
--- a/internal/providers/openrouter/client.go
+++ b/internal/providers/openrouter/client.go
@@ -65,9 +65,15 @@ func NewClient(apiKey string, modelID string, apiEndpoint string, logger logutil
 		apiEndpoint = "https://openrouter.ai/api/v1"
 	}
 
-	// Create HTTP client with reasonable timeout
+	// Create HTTP client with connection pooling and reasonable timeout
+	transport := &http.Transport{
+		MaxIdleConns:        100,
+		MaxIdleConnsPerHost: 10,
+		IdleConnTimeout:     90 * time.Second,
+	}
 	httpClient := &http.Client{
-		Timeout: 120 * time.Second, // 2 minute timeout for potentially long LLM generations
+		Transport: transport,
+		Timeout:   120 * time.Second, // 2 minute timeout for potentially long LLM generations
 	}
 
 	// Create client

--- a/internal/providers/openrouter/client_test.go
+++ b/internal/providers/openrouter/client_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/misty-step/thinktank/internal/logutil"
 	"github.com/stretchr/testify/assert"
@@ -95,6 +96,18 @@ func TestCreateClientThroughProvider(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNewClientConnectionPooling(t *testing.T) {
+	logger := logutil.NewLogger(logutil.InfoLevel, nil, "[test] ")
+	client, err := NewClient("sk-or-test-api-key", "anthropic/claude-3-opus-20240229", "", logger)
+	require.NoError(t, err)
+
+	transport, ok := client.httpClient.Transport.(*http.Transport)
+	require.True(t, ok)
+	assert.Equal(t, 100, transport.MaxIdleConns)
+	assert.Equal(t, 10, transport.MaxIdleConnsPerHost)
+	assert.Equal(t, 90*time.Second, transport.IdleConnTimeout)
 }
 
 // TestClientMethodsThroughProvider tests the client's methods

--- a/internal/providers/openrouter/client_test.go
+++ b/internal/providers/openrouter/client_test.go
@@ -102,6 +102,11 @@ func TestNewClientConnectionPooling(t *testing.T) {
 	logger := logutil.NewLogger(logutil.InfoLevel, nil, "[test] ")
 	client, err := NewClient("sk-or-test-api-key", "anthropic/claude-3-opus-20240229", "", logger)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		if err := client.Close(); err != nil {
+			t.Errorf("failed to close client: %v", err)
+		}
+	})
 
 	transport, ok := client.httpClient.Transport.(*http.Transport)
 	require.True(t, ok)


### PR DESCRIPTION
## Summary

- Configure `http.Transport` with connection pooling for the OpenRouter client
- Add test verifying default transport configuration

## Details

The OpenRouter client now reuses connections instead of establishing new ones per request, reducing latency for multi-model runs:

- `MaxIdleConns: 100` - total idle connections across all hosts
- `MaxIdleConnsPerHost: 10` - idle connections per host (OpenRouter)
- `IdleConnTimeout: 90s` - when to close idle connections

Expected performance improvement: ~100-200ms savings per subsequent request due to eliminated TCP/TLS handshake overhead.

## Test plan

- [x] New `TestNewClientConnectionPooling` verifies transport configuration
- [x] All existing tests pass with `-race`
- [x] golangci-lint clean

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved HTTP client connection pooling and cleanup for more efficient and reliable request handling.

* **Tests**
  * Added test coverage validating the HTTP client’s connection pooling and timeout behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->