### PR TITLE
chore: complete phrazzld → misty-step migration

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,9 +26,9 @@ builds:
         goarch: arm64
     ldflags:
       - -s -w
-      - -X github.com/phrazzld/thinktank/internal/version.Version={{.Version}}
-      - -X github.com/phrazzld/thinktank/internal/version.Commit={{.Commit}}
-      - -X github.com/phrazzld/thinktank/internal/version.BuildDate={{.Date}}
+      - -X github.com/misty-step/thinktank/internal/version.Version={{.Version}}
+      - -X github.com/misty-step/thinktank/internal/version.Commit={{.Commit}}
+      - -X github.com/misty-step/thinktank/internal/version.BuildDate={{.Date}}
 
 archives:
   - id: default
@@ -52,7 +52,7 @@ changelog:
 
 release:
   github:
-    owner: phrazzld
+    owner: misty-step
     name: thinktank
   # Don't mark as draft - release-please handles release creation
   draft: false

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 phrazzld
+Copyright (c) 2025 Misty Step
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/MODERN_CLI_OUTPUT.md
+++ b/docs/MODERN_CLI_OUTPUT.md
@@ -160,7 +160,7 @@ git checkout v1.x.x
 go install
 
 # Or download specific release
-curl -L https://github.com/phrazzld/thinktank/releases/download/v1.x.x/thinktank-linux-amd64 -o thinktank
+curl -L https://github.com/misty-step/thinktank/releases/download/v1.x.x/thinktank-linux-amd64 -o thinktank
 ```
 
 ## Migration Guide

--- a/docs/STRUCTURED_LOGGING.md
+++ b/docs/STRUCTURED_LOGGING.md
@@ -35,7 +35,7 @@ The project uses a dual-output logging system that combines clean console output
 import (
     "context"
     "log/slog"
-    "github.com/phrazzld/thinktank/internal/logutil"
+    "github.com/misty-step/thinktank/internal/logutil"
 )
 ```
 
@@ -436,7 +436,7 @@ log.Printf("Error processing request: %v", err)
 import (
     "context"
     "log/slog"
-    "github.com/phrazzld/thinktank/internal/logutil"
+    "github.com/misty-step/thinktank/internal/logutil"
 )
 
 ctx := logutil.WithCorrelationID(context.Background())

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -637,7 +637,7 @@ When reporting issues, include:
 
 ### Common Support Channels
 
-- **GitHub Issues**: [thinktank issues](https://github.com/phrazzld/thinktank/issues)
+- **GitHub Issues**: [thinktank issues](https://github.com/misty-step/thinktank/issues)
 - **Documentation**: Check existing docs in `/docs` directory
 - **Rate Limiting Guide**: [README.md](../README.md#rate-limiting--performance-optimization)
 - **Error Handling**: [ERROR_HANDLING_AND_LOGGING.md](ERROR_HANDLING_AND_LOGGING.md)
@@ -650,7 +650,7 @@ Before asking for help, try:
 - [ ] You can access provider APIs directly (curl tests)
 - [ ] You've tried with `--dry-run` to test configuration
 - [ ] You've tested with a smaller input set
-- [ ] You've checked recent [GitHub issues](https://github.com/phrazzld/thinktank/issues) for similar problems
+- [ ] You've checked recent [GitHub issues](https://github.com/misty-step/thinktank/issues) for similar problems
 - [ ] You've tried the conservative rate limiting settings shown above
 - [ ] You've enabled `--verbose` logging to see detailed error information
 

--- a/docs/ci-testing-guidelines.md
+++ b/docs/ci-testing-guidelines.md
@@ -18,7 +18,7 @@ This document establishes patterns and best practices for writing tests that wor
 For new performance tests, use the CI-aware framework in `internal/testutil/perftest`:
 
 ```go
-import "github.com/phrazzld/thinktank/internal/testutil/perftest"
+import "github.com/misty-step/thinktank/internal/testutil/perftest"
 
 func TestPerformance(t *testing.T) {
     // Automatically adjusts thresholds based on environment
@@ -240,7 +240,7 @@ func TestMultipleConfigurations(t *testing.T) {
 Use `testutil` package functions for secure API key handling:
 
 ```go
-import "github.com/phrazzld/thinktank/internal/testutil"
+import "github.com/misty-step/thinktank/internal/testutil"
 
 func TestWithSecureKey(t *testing.T) {
     // Skips test if no test API key provided

--- a/docs/coverage/COVERAGE_DISCREPANCY_ANALYSIS.md
+++ b/docs/coverage/COVERAGE_DISCREPANCY_ANALYSIS.md
@@ -12,12 +12,12 @@
 **ACTUAL REALITY**: OSFileSystem methods show **100% coverage**
 
 ```
-github.com/phrazzld/thinktank/internal/cli/run_implementations.go:18:  CreateTemp   100.0%
-github.com/phrazzld/thinktank/internal/cli/run_implementations.go:23:  WriteFile    100.0%
-github.com/phrazzld/thinktank/internal/cli/run_implementations.go:28:  ReadFile     100.0%
-github.com/phrazzld/thinktank/internal/cli/run_implementations.go:33:  Remove       100.0%
-github.com/phrazzld/thinktank/internal/cli/run_implementations.go:38:  MkdirAll     100.0%
-github.com/phrazzld/thinktank/internal/cli/run_implementations.go:43:  OpenFile     100.0%
+github.com/misty-step/thinktank/internal/cli/run_implementations.go:18:  CreateTemp   100.0%
+github.com/misty-step/thinktank/internal/cli/run_implementations.go:23:  WriteFile    100.0%
+github.com/misty-step/thinktank/internal/cli/run_implementations.go:28:  ReadFile     100.0%
+github.com/misty-step/thinktank/internal/cli/run_implementations.go:33:  Remove       100.0%
+github.com/misty-step/thinktank/internal/cli/run_implementations.go:38:  MkdirAll     100.0%
+github.com/misty-step/thinktank/internal/cli/run_implementations.go:43:  OpenFile     100.0%
 ```
 
 **Impact**: This removes one major blocker from the TODO.md plan.

--- a/docs/quality-dashboard/dashboard-data.json
+++ b/docs/quality-dashboard/dashboard-data.json
@@ -1,6 +1,6 @@
 {
   "generated_at": "2025-06-10T17:09:08Z",
-  "repository": "phrazzld/thinktank",
+  "repository": "misty-step/thinktank",
   "summary": {
     "overall_health": "16%",
     "coverage_success_rate": "50.00%",

--- a/scripts/quality/generate-dashboard.sh
+++ b/scripts/quality/generate-dashboard.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 SCRIPT_NAME="generate-dashboard.sh"
 OUTPUT_DIR="${OUTPUT_DIR:-docs/quality-dashboard}"
 DATA_FILE="${OUTPUT_DIR}/dashboard-data.json"
-REPO="${GITHUB_REPOSITORY:-phrazzld/thinktank}"
+REPO="${GITHUB_REPOSITORY:-misty-step/thinktank}"
 GITHUB_TOKEN="${GITHUB_TOKEN:-}"
 MAX_RUNS="${MAX_RUNS:-50}"
 VERBOSE="${VERBOSE:-false}"


### PR DESCRIPTION
## Summary
- Update remaining references to old personal account (`phrazzld`) to organization (`misty-step`)
- Affects: LICENSE, .goreleaser.yaml, docs/*, scripts/*

## Changes
| File | Change |
|------|--------|
| `.goreleaser.yaml` | ldflags + release owner |
| `LICENSE` | copyright holder |
| `docs/*` | GitHub links, import paths, download URLs |
| `scripts/quality/generate-dashboard.sh` | default repo fallback |

## Not Changed
- `CHANGELOG.md` - Historical commit links should reflect actual repo at time of commit

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository references throughout build configuration, licensing, documentation, and deployment tooling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->