### PR TITLE
feat: add observability infrastructure (metrics collection) (#141)

### DIFF
--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -70,6 +70,9 @@ FLAGS:
     --debug            Enable debug-level logging
                        Maximum verbosity for troubleshooting
 
+    --metrics-output FILE  Write execution metrics to FILE in JSON Lines format
+                           Captures timing, throughput, and error data for analysis
+
 EXAMPLES:
     # Basic usage - analyze a single directory
     thinktank instructions.md ./src

--- a/internal/cli/main_additional_test.go
+++ b/internal/cli/main_additional_test.go
@@ -243,7 +243,7 @@ func TestRunApplicationDryRun(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create a mock token service for testing
 			tokenService := thinktank.NewTokenCountingService()
-			err := runApplication(ctx, tt.config, logger, tokenService)
+			err := runApplication(ctx, tt.config, logger, tokenService, "")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("runApplication() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/internal/cli/simple_config.go
+++ b/internal/cli/simple_config.go
@@ -10,22 +10,15 @@ import (
 	"github.com/misty-step/thinktank/internal/models"
 )
 
-// SimplifiedConfig represents the essential configuration in exactly 34 bytes.
+// SimplifiedConfig represents the essential configuration.
 // Following Go's principle of "less is more", this struct contains only the
 // absolutely necessary fields with smart defaults for everything else.
-//
-// Memory layout (34 bytes total on 64-bit systems):
-// - InstructionsFile: 16 bytes (string header: ptr+len)
-// - TargetPath: 16 bytes (string header: ptr+len)
-// - Flags: 1 byte (bitfield for DryRun|Verbose|Synthesis)
-// - SafetyMargin: 1 byte (percentage 0-100)
 type SimplifiedConfig struct {
-	InstructionsFile string // 16 bytes (pointer + length on 64-bit)
-	TargetPath       string // 16 bytes (pointer + length on 64-bit)
-	Flags            uint8  // 1 byte bitfield
-	SafetyMargin     uint8  // 1 byte - safety margin percentage (0-50%)
-	// Note: Actual struct size may include padding. The 34-byte target
-	// refers to the logical data size, not the Go struct alignment.
+	InstructionsFile string // Path to instructions file
+	TargetPath       string // Space-joined target paths
+	MetricsOutput    string // Path for metrics output (empty = disabled)
+	Flags            uint8  // Bitfield for boolean flags
+	SafetyMargin     uint8  // Safety margin percentage (0-50%)
 }
 
 // Flag constants for bitwise operations - O(1) validation

--- a/internal/cli/simple_config.go
+++ b/internal/cli/simple_config.go
@@ -78,6 +78,18 @@ func (s *SimplifiedConfig) Validate() error {
 		return fmt.Errorf("instructions file path too long (max %d characters): %d characters", maxPathLength, len(s.InstructionsFile))
 	}
 
+	// Validate metrics output path
+	if s.MetricsOutput != "" {
+		if len(s.MetricsOutput) > maxPathLength {
+			return fmt.Errorf("metrics output path too long (max %d characters): %d characters", maxPathLength, len(s.MetricsOutput))
+		}
+		// Check for path traversal
+		cleanPath := filepath.Clean(s.MetricsOutput)
+		if strings.Contains(cleanPath, "..") {
+			return fmt.Errorf("metrics output path cannot contain directory traversal (..)")
+		}
+	}
+
 	// 2. Enhanced positional argument validation with file extension checks
 	// For dry-run mode, only validate if instructions file is provided
 	if s.HasFlag(FlagDryRun) {

--- a/internal/cli/simple_config_test.go
+++ b/internal/cli/simple_config_test.go
@@ -4,6 +4,7 @@ package cli
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"unsafe"
 
@@ -331,6 +332,38 @@ func TestValidate(t *testing.T) {
 			},
 			setup: func() {
 				_ = os.Unsetenv("OPENROUTER_API_KEY")
+			},
+			wantErr: false,
+		},
+		{
+			name: "metrics output path traversal blocked",
+			config: SimplifiedConfig{
+				InstructionsFile: validInstFile,
+				TargetPath:       validTargetDir,
+				MetricsOutput:    "../../../etc/passwd",
+				Flags:            FlagDryRun,
+			},
+			wantErr: true,
+			errMsg:  "metrics output path cannot contain directory traversal",
+		},
+		{
+			name: "metrics output path too long",
+			config: SimplifiedConfig{
+				InstructionsFile: validInstFile,
+				TargetPath:       validTargetDir,
+				MetricsOutput:    strings.Repeat("a", 300),
+				Flags:            FlagDryRun,
+			},
+			wantErr: true,
+			errMsg:  "metrics output path too long",
+		},
+		{
+			name: "valid metrics output path",
+			config: SimplifiedConfig{
+				InstructionsFile: validInstFile,
+				TargetPath:       validTargetDir,
+				MetricsOutput:    "metrics.jsonl",
+				Flags:            FlagDryRun,
 			},
 			wantErr: false,
 		},

--- a/internal/cli/simple_config_test.go
+++ b/internal/cli/simple_config_test.go
@@ -18,13 +18,17 @@ func TestSimplifiedConfigSize(t *testing.T) {
 	actualSize := unsafe.Sizeof(config)
 
 	// The struct should be compact - much smaller than the 200+ byte CliConfig
-	// Go's alignment may add padding, but the logical data is 33 bytes
-	assert.LessOrEqual(t, actualSize, uintptr(48), "SimplifiedConfig should be ≤48 bytes with alignment")
-	assert.GreaterOrEqual(t, actualSize, uintptr(33), "SimplifiedConfig should be ≥33 bytes of logical data")
+	// With MetricsOutput field: 3 strings (48 bytes) + 2 uint8 (2 bytes) + padding
+	assert.LessOrEqual(t, actualSize, uintptr(64), "SimplifiedConfig should be ≤64 bytes with alignment")
+	assert.GreaterOrEqual(t, actualSize, uintptr(50), "SimplifiedConfig should be ≥50 bytes of logical data")
 
-	// Verify the logical data size is exactly 33 bytes (2 strings + 1 byte)
-	logicalSize := unsafe.Sizeof(config.InstructionsFile) + unsafe.Sizeof(config.TargetPath) + unsafe.Sizeof(config.Flags)
-	assert.Equal(t, uintptr(33), logicalSize, "Logical data size should be exactly 33 bytes")
+	// Verify the logical data size: 3 strings + 2 uint8
+	logicalSize := unsafe.Sizeof(config.InstructionsFile) +
+		unsafe.Sizeof(config.TargetPath) +
+		unsafe.Sizeof(config.MetricsOutput) +
+		unsafe.Sizeof(config.Flags) +
+		unsafe.Sizeof(config.SafetyMargin)
+	assert.Equal(t, uintptr(50), logicalSize, "Logical data size should be exactly 50 bytes")
 }
 
 // TestSimplifiedConfigFields validates the required fields are present

--- a/internal/cli/simple_parser.go
+++ b/internal/cli/simple_parser.go
@@ -45,6 +45,7 @@ func ParseSimpleArgsWithArgs(args []string) (*SimplifiedConfig, error) {
 	// First pass: separate positional args from flags
 	var instructionsFile string
 	var targetPaths []string
+	var metricsOutput string
 	flags := uint8(0)
 	safetyMargin := uint8(10) // Default 10% safety margin
 
@@ -134,6 +135,22 @@ func ParseSimpleArgsWithArgs(args []string) (*SimplifiedConfig, error) {
 			}
 			safetyMargin = parsedMargin
 
+		case arg == "--metrics-output":
+			// --metrics-output flag requires a value
+			if i+1 >= len(args) {
+				return nil, fmt.Errorf("--metrics-output flag requires a value")
+			}
+			i++
+			metricsOutput = args[i]
+
+		case strings.HasPrefix(arg, "--metrics-output="):
+			// Handle --metrics-output=value format
+			value := strings.TrimPrefix(arg, "--metrics-output=")
+			if value == "" {
+				return nil, fmt.Errorf("--metrics-output flag requires a non-empty value")
+			}
+			metricsOutput = value
+
 		case strings.HasPrefix(arg, "--"):
 			// Unknown flag - fail fast with clear error message
 			return nil, fmt.Errorf("unknown flag: %s", arg)
@@ -171,6 +188,7 @@ func ParseSimpleArgsWithArgs(args []string) (*SimplifiedConfig, error) {
 	config := &SimplifiedConfig{
 		InstructionsFile: instructionsFile,
 		TargetPath:       targetPath,
+		MetricsOutput:    metricsOutput,
 		Flags:            flags,
 		SafetyMargin:     safetyMargin,
 	}

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -1,0 +1,156 @@
+package metrics
+
+import (
+	"io"
+	"sync"
+	"time"
+)
+
+// Collector records metrics during execution.
+type Collector interface {
+	// RecordDuration records a duration metric with optional labels (key, value pairs).
+	RecordDuration(name string, duration time.Duration, labels ...string)
+
+	// StartTimer returns a stop function that records duration when called.
+	StartTimer(name string, labels ...string) func()
+
+	// IncrCounter increments a counter by 1.
+	IncrCounter(name string, labels ...string)
+
+	// AddCounter adds delta to a counter.
+	AddCounter(name string, delta int64, labels ...string)
+
+	// SetGauge sets a gauge value.
+	SetGauge(name string, value float64, labels ...string)
+
+	// Flush exports collected metrics and clears the buffer.
+	Flush() error
+
+	// Metrics returns all collected metrics.
+	Metrics() []Metric
+}
+
+// DefaultCollector is a thread-safe metrics collector.
+type DefaultCollector struct {
+	mu       sync.Mutex
+	metrics  []Metric
+	exporter Exporter
+	clock    func() time.Time // for testing
+}
+
+// NewCollector creates a new DefaultCollector with the given exporter.
+func NewCollector(exporter Exporter) *DefaultCollector {
+	return &DefaultCollector{
+		metrics:  make([]Metric, 0),
+		exporter: exporter,
+		clock:    time.Now,
+	}
+}
+
+// RecordDuration records a duration metric in milliseconds.
+func (c *DefaultCollector) RecordDuration(name string, duration time.Duration, labels ...string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.metrics = append(c.metrics, Metric{
+		Timestamp: c.clock(),
+		Name:      name,
+		Type:      TypeDuration,
+		Value:     float64(duration.Milliseconds()),
+		Labels:    parseLabels(labels),
+	})
+}
+
+// StartTimer returns a stop function that records duration when called.
+func (c *DefaultCollector) StartTimer(name string, labels ...string) func() {
+	start := c.clock()
+	return func() {
+		c.RecordDuration(name, c.clock().Sub(start), labels...)
+	}
+}
+
+// IncrCounter increments a counter by 1.
+func (c *DefaultCollector) IncrCounter(name string, labels ...string) {
+	c.AddCounter(name, 1, labels...)
+}
+
+// AddCounter adds delta to a counter.
+func (c *DefaultCollector) AddCounter(name string, delta int64, labels ...string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.metrics = append(c.metrics, Metric{
+		Timestamp: c.clock(),
+		Name:      name,
+		Type:      TypeCounter,
+		Value:     float64(delta),
+		Labels:    parseLabels(labels),
+	})
+}
+
+// SetGauge sets a gauge value.
+func (c *DefaultCollector) SetGauge(name string, value float64, labels ...string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.metrics = append(c.metrics, Metric{
+		Timestamp: c.clock(),
+		Name:      name,
+		Type:      TypeGauge,
+		Value:     value,
+		Labels:    parseLabels(labels),
+	})
+}
+
+// Flush exports collected metrics and clears the buffer.
+func (c *DefaultCollector) Flush() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.exporter == nil {
+		return nil
+	}
+
+	if err := c.exporter.Export(c.metrics); err != nil {
+		return err
+	}
+	c.metrics = c.metrics[:0]
+	return nil
+}
+
+// Metrics returns a copy of all collected metrics.
+func (c *DefaultCollector) Metrics() []Metric {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	result := make([]Metric, len(c.metrics))
+	copy(result, c.metrics)
+	return result
+}
+
+// NoopCollector is a no-op implementation for disabled metrics.
+type NoopCollector struct{}
+
+// NewNoopCollector creates a new NoopCollector.
+func NewNoopCollector() *NoopCollector {
+	return &NoopCollector{}
+}
+
+func (n *NoopCollector) RecordDuration(string, time.Duration, ...string) {}
+func (n *NoopCollector) StartTimer(string, ...string) func()             { return func() {} }
+func (n *NoopCollector) IncrCounter(string, ...string)                   {}
+func (n *NoopCollector) AddCounter(string, int64, ...string)             {}
+func (n *NoopCollector) SetGauge(string, float64, ...string)             {}
+func (n *NoopCollector) Flush() error                                    { return nil }
+func (n *NoopCollector) Metrics() []Metric                               { return nil }
+
+// Exporter defines the interface for exporting metrics.
+type Exporter interface {
+	Export(metrics []Metric) error
+}
+
+// JSONLinesExporter writes metrics as JSON Lines to an io.Writer.
+type JSONLinesExporter struct {
+	writer io.Writer
+}
+
+// NewJSONLinesExporter creates a new JSONLinesExporter.
+func NewJSONLinesExporter(w io.Writer) *JSONLinesExporter {
+	return &JSONLinesExporter{writer: w}
+}

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -35,16 +35,30 @@ type DefaultCollector struct {
 	mu       sync.Mutex
 	metrics  []Metric
 	exporter Exporter
-	clock    func() time.Time // for testing
+	clock    func() time.Time // immutable after construction
+}
+
+// CollectorOption configures a DefaultCollector.
+type CollectorOption func(*DefaultCollector)
+
+// WithClock sets a custom clock function (for testing).
+func WithClock(clock func() time.Time) CollectorOption {
+	return func(c *DefaultCollector) {
+		c.clock = clock
+	}
 }
 
 // NewCollector creates a new DefaultCollector with the given exporter.
-func NewCollector(exporter Exporter) *DefaultCollector {
-	return &DefaultCollector{
+func NewCollector(exporter Exporter, opts ...CollectorOption) *DefaultCollector {
+	c := &DefaultCollector{
 		metrics:  make([]Metric, 0),
 		exporter: exporter,
 		clock:    time.Now,
 	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
 }
 
 // RecordDuration records a duration metric in milliseconds.

--- a/internal/metrics/collector_test.go
+++ b/internal/metrics/collector_test.go
@@ -1,0 +1,291 @@
+package metrics
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDefaultCollector_RecordDuration(t *testing.T) {
+	c := NewCollector(nil)
+	fixedTime := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+	c.clock = func() time.Time { return fixedTime }
+
+	c.RecordDuration("api_latency_ms", 150*time.Millisecond, "model", "gpt-4o")
+
+	metrics := c.Metrics()
+	if len(metrics) != 1 {
+		t.Fatalf("expected 1 metric, got %d", len(metrics))
+	}
+
+	m := metrics[0]
+	if m.Name != "api_latency_ms" {
+		t.Errorf("expected name api_latency_ms, got %s", m.Name)
+	}
+	if m.Type != TypeDuration {
+		t.Errorf("expected type %s, got %s", TypeDuration, m.Type)
+	}
+	if m.Value != 150 {
+		t.Errorf("expected value 150, got %f", m.Value)
+	}
+	if m.Labels["model"] != "gpt-4o" {
+		t.Errorf("expected label model=gpt-4o, got %s", m.Labels["model"])
+	}
+	if !m.Timestamp.Equal(fixedTime) {
+		t.Errorf("expected timestamp %v, got %v", fixedTime, m.Timestamp)
+	}
+}
+
+func TestDefaultCollector_StartTimer(t *testing.T) {
+	c := NewCollector(nil)
+	callCount := 0
+	times := []time.Time{
+		time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC),         // StartTimer start
+		time.Date(2024, 1, 15, 10, 30, 1, 0, time.UTC),         // stop() calculates duration
+		time.Date(2024, 1, 15, 10, 30, 1, 500000000, time.UTC), // RecordDuration timestamp
+	}
+	c.clock = func() time.Time {
+		idx := callCount
+		if idx >= len(times) {
+			idx = len(times) - 1
+		}
+		callCount++
+		return times[idx]
+	}
+
+	stop := c.StartTimer("operation_ms", "op", "test")
+	stop()
+
+	metrics := c.Metrics()
+	if len(metrics) != 1 {
+		t.Fatalf("expected 1 metric, got %d", len(metrics))
+	}
+
+	m := metrics[0]
+	if m.Name != "operation_ms" {
+		t.Errorf("expected name operation_ms, got %s", m.Name)
+	}
+	if m.Value != 1000 {
+		t.Errorf("expected value 1000ms, got %f", m.Value)
+	}
+	if m.Labels["op"] != "test" {
+		t.Errorf("expected label op=test, got %s", m.Labels["op"])
+	}
+}
+
+func TestDefaultCollector_IncrCounter(t *testing.T) {
+	c := NewCollector(nil)
+
+	c.IncrCounter("requests_total", "status", "success")
+	c.IncrCounter("requests_total", "status", "success")
+
+	metrics := c.Metrics()
+	if len(metrics) != 2 {
+		t.Fatalf("expected 2 metrics, got %d", len(metrics))
+	}
+
+	for _, m := range metrics {
+		if m.Type != TypeCounter {
+			t.Errorf("expected type %s, got %s", TypeCounter, m.Type)
+		}
+		if m.Value != 1 {
+			t.Errorf("expected value 1, got %f", m.Value)
+		}
+	}
+}
+
+func TestDefaultCollector_AddCounter(t *testing.T) {
+	c := NewCollector(nil)
+
+	c.AddCounter("bytes_processed", 1024, "source", "file")
+
+	metrics := c.Metrics()
+	if len(metrics) != 1 {
+		t.Fatalf("expected 1 metric, got %d", len(metrics))
+	}
+
+	m := metrics[0]
+	if m.Value != 1024 {
+		t.Errorf("expected value 1024, got %f", m.Value)
+	}
+}
+
+func TestDefaultCollector_SetGauge(t *testing.T) {
+	c := NewCollector(nil)
+
+	c.SetGauge("token_utilization_pct", 75.5, "model", "gpt-4o")
+
+	metrics := c.Metrics()
+	if len(metrics) != 1 {
+		t.Fatalf("expected 1 metric, got %d", len(metrics))
+	}
+
+	m := metrics[0]
+	if m.Type != TypeGauge {
+		t.Errorf("expected type %s, got %s", TypeGauge, m.Type)
+	}
+	if m.Value != 75.5 {
+		t.Errorf("expected value 75.5, got %f", m.Value)
+	}
+}
+
+func TestDefaultCollector_Flush(t *testing.T) {
+	var buf bytes.Buffer
+	exporter := NewJSONLinesExporter(&buf)
+	c := NewCollector(exporter)
+	fixedTime := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+	c.clock = func() time.Time { return fixedTime }
+
+	c.RecordDuration("api_latency_ms", 100*time.Millisecond, "model", "gpt-4o")
+	c.IncrCounter("requests_total")
+
+	if err := c.Flush(); err != nil {
+		t.Fatalf("flush failed: %v", err)
+	}
+
+	// Verify buffer was cleared
+	if len(c.Metrics()) != 0 {
+		t.Errorf("expected metrics to be cleared after flush, got %d", len(c.Metrics()))
+	}
+
+	// Verify output
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d: %s", len(lines), buf.String())
+	}
+
+	var m Metric
+	if err := json.Unmarshal([]byte(lines[0]), &m); err != nil {
+		t.Fatalf("failed to unmarshal first line: %v", err)
+	}
+	if m.Name != "api_latency_ms" {
+		t.Errorf("expected first metric name api_latency_ms, got %s", m.Name)
+	}
+}
+
+func TestDefaultCollector_FlushWithNilExporter(t *testing.T) {
+	c := NewCollector(nil)
+	c.IncrCounter("test")
+
+	if err := c.Flush(); err != nil {
+		t.Errorf("flush with nil exporter should succeed, got: %v", err)
+	}
+}
+
+func TestDefaultCollector_ThreadSafety(t *testing.T) {
+	c := NewCollector(nil)
+	done := make(chan struct{})
+
+	// Concurrent writes
+	for i := 0; i < 10; i++ {
+		go func(id int) {
+			for j := 0; j < 100; j++ {
+				c.IncrCounter("concurrent_counter", "goroutine", string(rune('0'+id)))
+			}
+			done <- struct{}{}
+		}(i)
+	}
+
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+
+	metrics := c.Metrics()
+	if len(metrics) != 1000 {
+		t.Errorf("expected 1000 metrics, got %d", len(metrics))
+	}
+}
+
+func TestNoopCollector(t *testing.T) {
+	c := NewNoopCollector()
+
+	// None of these should panic
+	c.RecordDuration("test", time.Second)
+	stop := c.StartTimer("test")
+	stop()
+	c.IncrCounter("test")
+	c.AddCounter("test", 10)
+	c.SetGauge("test", 1.0)
+
+	if err := c.Flush(); err != nil {
+		t.Errorf("noop flush should succeed, got: %v", err)
+	}
+
+	if c.Metrics() != nil {
+		t.Error("noop metrics should return nil")
+	}
+}
+
+func TestJSONLinesExporter(t *testing.T) {
+	var buf bytes.Buffer
+	exporter := NewJSONLinesExporter(&buf)
+	fixedTime := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+
+	metrics := []Metric{
+		{
+			Timestamp: fixedTime,
+			Name:      "api_latency_ms",
+			Type:      TypeDuration,
+			Value:     150,
+			Labels:    map[string]string{"model": "gpt-4o"},
+		},
+	}
+
+	if err := exporter.Export(metrics); err != nil {
+		t.Fatalf("export failed: %v", err)
+	}
+
+	expected := `{"timestamp":"2024-01-15T10:30:00Z","name":"api_latency_ms","type":"duration","value":150,"labels":{"model":"gpt-4o"}}`
+	got := strings.TrimSpace(buf.String())
+	if got != expected {
+		t.Errorf("unexpected output:\ngot:  %s\nwant: %s", got, expected)
+	}
+}
+
+func TestParseLabels(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected map[string]string
+	}{
+		{
+			name:     "empty",
+			input:    []string{},
+			expected: nil,
+		},
+		{
+			name:     "single pair",
+			input:    []string{"key", "value"},
+			expected: map[string]string{"key": "value"},
+		},
+		{
+			name:     "multiple pairs",
+			input:    []string{"a", "1", "b", "2"},
+			expected: map[string]string{"a": "1", "b": "2"},
+		},
+		{
+			name:     "odd number",
+			input:    []string{"key"},
+			expected: map[string]string{"key": ""},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseLabels(tt.input)
+			if tt.expected == nil {
+				if got != nil {
+					t.Errorf("expected nil, got %v", got)
+				}
+				return
+			}
+			for k, v := range tt.expected {
+				if got[k] != v {
+					t.Errorf("expected %s=%s, got %s=%s", k, v, k, got[k])
+				}
+			}
+		})
+	}
+}

--- a/internal/metrics/exporter.go
+++ b/internal/metrics/exporter.go
@@ -1,0 +1,20 @@
+package metrics
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Export writes metrics as JSON Lines to the underlying writer.
+func (e *JSONLinesExporter) Export(metrics []Metric) error {
+	for _, m := range metrics {
+		data, err := json.Marshal(m)
+		if err != nil {
+			return fmt.Errorf("failed to marshal metric %s: %w", m.Name, err)
+		}
+		if _, err := e.writer.Write(append(data, '\n')); err != nil {
+			return fmt.Errorf("failed to write metric %s: %w", m.Name, err)
+		}
+	}
+	return nil
+}

--- a/internal/metrics/types.go
+++ b/internal/metrics/types.go
@@ -1,0 +1,45 @@
+// Package metrics provides observability infrastructure for collecting
+// and exporting runtime metrics like durations, counters, and gauges.
+package metrics
+
+import "time"
+
+// MetricType represents the type of metric being recorded.
+type MetricType string
+
+const (
+	// TypeCounter represents a monotonically increasing counter.
+	TypeCounter MetricType = "counter"
+	// TypeGauge represents a point-in-time value that can go up or down.
+	TypeGauge MetricType = "gauge"
+	// TypeDuration represents a time duration metric.
+	TypeDuration MetricType = "duration"
+)
+
+// Metric represents a single metric data point.
+type Metric struct {
+	Timestamp time.Time         `json:"timestamp"`
+	Name      string            `json:"name"`
+	Type      MetricType        `json:"type"`
+	Value     float64           `json:"value"`
+	Labels    map[string]string `json:"labels,omitempty"`
+}
+
+// parseLabels converts variadic key=value string pairs into a map.
+// Labels must be provided as alternating key, value pairs.
+// If an odd number of strings is provided, the last key gets an empty value.
+func parseLabels(labels []string) map[string]string {
+	if len(labels) == 0 {
+		return nil
+	}
+	result := make(map[string]string)
+	for i := 0; i < len(labels); i += 2 {
+		key := labels[i]
+		value := ""
+		if i+1 < len(labels) {
+			value = labels[i+1]
+		}
+		result[key] = value
+	}
+	return result
+}

--- a/internal/thinktank/orchestrator/model_processing.go
+++ b/internal/thinktank/orchestrator/model_processing.go
@@ -413,6 +413,10 @@ func (o *Orchestrator) processModelWithRateLimit(
 		result.err = err
 		result.duration = time.Since(totalStart)
 
+		// Record per-model failure metrics
+		o.metricsCollector.RecordDuration("model_duration_ms", result.duration, "model", modelName, "status", "failed")
+		o.metricsCollector.IncrCounter("models_processed_total", "model", modelName, "status", "failed")
+
 		// Update status to failed
 		errorMsg := o.getUserFriendlyErrorMessage(err, modelName)
 		o.consoleWriter.UpdateModelStatus(modelName, logutil.StatusFailed, result.duration, errorMsg)
@@ -428,6 +432,10 @@ func (o *Orchestrator) processModelWithRateLimit(
 	// Store content and duration
 	result.content = content
 	result.duration = time.Since(totalStart)
+
+	// Record per-model metrics
+	o.metricsCollector.RecordDuration("model_duration_ms", result.duration, "model", modelName, "status", "success")
+	o.metricsCollector.IncrCounter("models_processed_total", "model", modelName, "status", "success")
 
 	// Update status to completed
 	o.consoleWriter.UpdateModelStatus(modelName, logutil.StatusCompleted, result.duration, "")

--- a/internal/thinktank/orchestrator/orchestrator_metrics_test.go
+++ b/internal/thinktank/orchestrator/orchestrator_metrics_test.go
@@ -1,0 +1,227 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/misty-step/thinktank/internal/config"
+	"github.com/misty-step/thinktank/internal/fileutil"
+	"github.com/misty-step/thinktank/internal/logutil"
+	"github.com/misty-step/thinktank/internal/metrics"
+	"github.com/misty-step/thinktank/internal/ratelimit"
+	"github.com/misty-step/thinktank/internal/thinktank/interfaces"
+)
+
+// TestOrchestratorMetricsIntegration verifies that metrics are recorded during orchestrator execution
+func TestOrchestratorMetricsIntegration(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a real metrics collector (no exporter needed for test)
+	metricsCollector := metrics.NewCollector(nil)
+
+	// Create mock dependencies
+	mockLogger := &MockLogger{}
+	mockAuditLogger := NewMockAuditLogger()
+	mockAPIService := &MockAPIService{}
+	mockFileWriter := &MockFileWriter{}
+	mockContextGatherer := &MockContextGatherer{}
+	mockTokenCountingService := &MockTokenCountingService{
+		CountTokensResult: interfaces.TokenCountingResult{
+			TotalTokens: 1000,
+		},
+	}
+
+	consoleWriter := logutil.NewConsoleWriterWithOptions(logutil.ConsoleWriterOptions{
+		IsTerminalFunc: func() bool { return false },
+	})
+	rateLimiter := ratelimit.NewRateLimiter(5, 60)
+
+	cfg := &config.CliConfig{
+		ModelNames: []string{"mock-model"},
+		OutputDir:  t.TempDir(),
+		Paths:      []string{"."},
+		DryRun:     true, // Use dry run to avoid actual API calls
+	}
+
+	deps := OrchestratorDeps{
+		APIService:           mockAPIService,
+		ContextGatherer:      mockContextGatherer,
+		FileWriter:           mockFileWriter,
+		AuditLogger:          mockAuditLogger,
+		RateLimiter:          rateLimiter,
+		Config:               cfg,
+		Logger:               mockLogger,
+		ConsoleWriter:        consoleWriter,
+		TokenCountingService: mockTokenCountingService,
+		MetricsCollector:     metricsCollector,
+	}
+
+	orch := NewOrchestrator(deps)
+
+	// Run the orchestrator in dry-run mode
+	err := orch.Run(ctx, "Test instructions")
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+
+	// Verify metrics were recorded
+	allMetrics := metricsCollector.Metrics()
+	if len(allMetrics) == 0 {
+		t.Fatal("Expected metrics to be recorded, got none")
+	}
+
+	// Check for required metrics
+	metricNames := make(map[string]bool)
+	for _, m := range allMetrics {
+		metricNames[m.Name] = true
+	}
+
+	// total_duration_ms should always be recorded
+	if !metricNames["total_duration_ms"] {
+		t.Error("Expected total_duration_ms metric to be recorded")
+	}
+
+	// context_gather_duration_ms should be recorded
+	if !metricNames["context_gather_duration_ms"] {
+		t.Error("Expected context_gather_duration_ms metric to be recorded")
+	}
+
+	// Verify metric types
+	for _, m := range allMetrics {
+		if m.Name == "total_duration_ms" || m.Name == "context_gather_duration_ms" {
+			if m.Type != metrics.TypeDuration {
+				t.Errorf("Expected %s to be type duration, got %s", m.Name, m.Type)
+			}
+			if m.Value < 0 {
+				t.Errorf("Expected %s value >= 0, got %f", m.Name, m.Value)
+			}
+		}
+	}
+}
+
+// TestOrchestratorMetricsWithNilCollector verifies that nil collector is replaced with noop
+func TestOrchestratorMetricsWithNilCollector(t *testing.T) {
+	ctx := context.Background()
+
+	// Create mock dependencies WITHOUT a metrics collector
+	mockLogger := &MockLogger{}
+	mockAuditLogger := NewMockAuditLogger()
+	mockAPIService := &MockAPIService{}
+	mockFileWriter := &MockFileWriter{}
+	mockContextGatherer := &MockContextGatherer{}
+	mockTokenCountingService := &MockTokenCountingService{
+		CountTokensResult: interfaces.TokenCountingResult{
+			TotalTokens: 1000,
+		},
+	}
+
+	consoleWriter := logutil.NewConsoleWriterWithOptions(logutil.ConsoleWriterOptions{
+		IsTerminalFunc: func() bool { return false },
+	})
+	rateLimiter := ratelimit.NewRateLimiter(5, 60)
+
+	cfg := &config.CliConfig{
+		ModelNames: []string{"mock-model"},
+		OutputDir:  t.TempDir(),
+		Paths:      []string{"."},
+		DryRun:     true,
+	}
+
+	deps := OrchestratorDeps{
+		APIService:           mockAPIService,
+		ContextGatherer:      mockContextGatherer,
+		FileWriter:           mockFileWriter,
+		AuditLogger:          mockAuditLogger,
+		RateLimiter:          rateLimiter,
+		Config:               cfg,
+		Logger:               mockLogger,
+		ConsoleWriter:        consoleWriter,
+		TokenCountingService: mockTokenCountingService,
+		MetricsCollector:     nil, // Explicitly nil
+	}
+
+	orch := NewOrchestrator(deps)
+
+	// Run should not panic with nil metrics collector
+	err := orch.Run(ctx, "Test instructions")
+	if err != nil {
+		t.Fatalf("Run() with nil metrics collector unexpected error: %v", err)
+	}
+}
+
+// TestOrchestratorMetricsErrorPhases verifies error counters are incremented on failures
+func TestOrchestratorMetricsErrorPhases(t *testing.T) {
+	// This test verifies that when context gathering fails,
+	// the error counter is incremented with the correct phase label
+	ctx := context.Background()
+
+	metricsCollector := metrics.NewCollector(nil)
+
+	mockLogger := &MockLogger{}
+	mockAuditLogger := NewMockAuditLogger()
+	mockAPIService := &MockAPIService{}
+	mockFileWriter := &MockFileWriter{}
+	mockTokenCountingService := &MockTokenCountingService{}
+
+	// Create a context gatherer that returns an error
+	errorContextGatherer := &erroringContextGatherer{}
+
+	consoleWriter := logutil.NewConsoleWriterWithOptions(logutil.ConsoleWriterOptions{
+		IsTerminalFunc: func() bool { return false },
+	})
+	rateLimiter := ratelimit.NewRateLimiter(5, 60)
+
+	cfg := &config.CliConfig{
+		ModelNames: []string{"mock-model"},
+		OutputDir:  t.TempDir(),
+		Paths:      []string{"."},
+	}
+
+	deps := OrchestratorDeps{
+		APIService:           mockAPIService,
+		ContextGatherer:      errorContextGatherer,
+		FileWriter:           mockFileWriter,
+		AuditLogger:          mockAuditLogger,
+		RateLimiter:          rateLimiter,
+		Config:               cfg,
+		Logger:               mockLogger,
+		ConsoleWriter:        consoleWriter,
+		TokenCountingService: mockTokenCountingService,
+		MetricsCollector:     metricsCollector,
+	}
+
+	orch := NewOrchestrator(deps)
+
+	// Run should fail due to context gathering error
+	err := orch.Run(ctx, "Test instructions")
+	if err == nil {
+		t.Fatal("Expected Run() to fail due to context gathering error")
+	}
+
+	// Verify error counter was incremented
+	allMetrics := metricsCollector.Metrics()
+	foundErrorCounter := false
+	for _, m := range allMetrics {
+		if m.Name == "execution_errors_total" && m.Type == metrics.TypeCounter {
+			foundErrorCounter = true
+			if m.Labels["phase"] != "context_gather" {
+				t.Errorf("Expected error phase 'context_gather', got '%s'", m.Labels["phase"])
+			}
+		}
+	}
+
+	if !foundErrorCounter {
+		t.Error("Expected execution_errors_total counter to be recorded")
+	}
+}
+
+// erroringContextGatherer is a mock that always returns an error
+type erroringContextGatherer struct{}
+
+func (e *erroringContextGatherer) GatherContext(ctx context.Context, config interfaces.GatherConfig) ([]fileutil.FileMeta, *interfaces.ContextStats, error) {
+	return nil, nil, context.DeadlineExceeded
+}
+
+func (e *erroringContextGatherer) DisplayDryRunInfo(ctx context.Context, stats *interfaces.ContextStats) error {
+	return nil
+}


### PR DESCRIPTION
## Summary

- Add `internal/metrics` package with `MetricsCollector` interface
- Integrate metrics collection into orchestrator for execution timing
- Add `--metrics-output` CLI flag to enable metrics export to JSON Lines file

## Changes

### New Package: `internal/metrics/`
- `Collector` interface for recording durations, counters, and gauges
- `DefaultCollector` with thread-safe implementation
- `NoopCollector` for disabled metrics (default when no `--metrics-output`)
- `JSONLinesExporter` for file output

### Orchestrator Integration
Records metrics for:
- Total execution duration
- Context gathering duration  
- Model processing duration
- Per-model duration and success/failure status
- Output save duration
- File/line/char counts from context

### CLI
- New `--metrics-output FILE` flag to enable metrics export
- Metrics collection is opt-in (disabled by default)

## Test plan
- [x] Unit tests for metrics package (93.9% coverage)
- [x] All existing tests pass with `-race`
- [x] golangci-lint clean
- [x] Manual test: `thinktank --dry-run --metrics-output` creates file
- [x] Manual test: help shows new flag

## Output format

Metrics are written as JSON Lines:
```json
{"timestamp":"2024-01-15T10:30:00Z","name":"total_duration_ms","type":"duration","value":5000}
{"timestamp":"2024-01-15T10:30:00Z","name":"model_duration_ms","type":"duration","value":2500,"labels":{"model":"gpt-4o","status":"success"}}
```

Closes #141

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --metrics-output flag to export execution metrics in JSON Lines format.
  * Integrated optional metrics collection across the app (timings, counters, gauges, per-model and phase metrics); collection is disabled when no output is configured.

* **Tests**
  * Added comprehensive tests covering metrics recording, exporting, concurrency, noop behavior, and orchestrator integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->