### PR TITLE
feat(ux): add loading indicator during context gathering phase

### DIFF
--- a/internal/thinktank/context.go
+++ b/internal/thinktank/context.go
@@ -81,6 +81,7 @@ func (cg *contextGatherer) GatherContext(ctx context.Context, config interfaces.
 	}
 
 	// Gather project context
+	cg.consoleWriter.StatusMessage("Scanning files...")
 	contextFiles, processedFilesCount, err := fileutil.GatherProjectContext(config.Paths, fileConfig)
 
 	// Calculate duration in milliseconds
@@ -139,6 +140,7 @@ func (cg *contextGatherer) GatherContext(ctx context.Context, config interfaces.
 	if processedFilesCount > 0 {
 		cg.logger.InfoContext(ctx, "Context gathered: %d files, %d lines, %d chars",
 			processedFilesCount, lineCount, charCount)
+		cg.consoleWriter.StatusMessage(fmt.Sprintf("Context gathered: %d files, %d lines, %d chars", processedFilesCount, lineCount, charCount))
 
 		// Additional detailed debug information if needed
 		if config.LogLevel == logutil.DebugLevel && !cg.dryRun {


### PR DESCRIPTION
## Summary

- Add visible feedback during file scanning phase to prevent users from thinking the tool is frozen on large codebases
- Shows "Scanning files..." before scanning begins
- Shows "Context gathered: N files, N lines, N chars" after scanning completes

## Before

```
$ thinktank --instructions prompt.txt ./large-codebase
[no output for 10+ seconds while scanning]
```

## After

```
$ thinktank --instructions prompt.txt ./large-codebase
Scanning files...
Context gathered: 1,234 files, 45,678 lines, 123,456 chars
```

## Test plan

- [x] Tests pass with race detector (`go test -race ./...`)
- [x] Build succeeds (`go build ./...`)
- [x] Lint passes (`golangci-lint run ./...`)
- [x] Pre-push hooks pass

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added progress feedback during file scanning and context analysis, displaying real-time status updates with the number of files processed, lines counted, and total characters analyzed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->