### PR TITLE
fix(cli): remove t.Skip from TestProviderRateLimiter_ConcurrentAccess

### DIFF
--- a/internal/cli/rate_limiter_test.go
+++ b/internal/cli/rate_limiter_test.go
@@ -319,7 +319,6 @@ func TestCalculateBackoffDelay(t *testing.T) {
 
 // TestProviderRateLimiter_ConcurrentAccess tests thread safety
 func TestProviderRateLimiter_ConcurrentAccess(t *testing.T) {
-	t.Skip("TODO: deadlocks on semaphore Acquire — see thinktank#206")
 	prl := NewProviderRateLimiter(10, nil)
 	ctx := context.Background()
 


### PR DESCRIPTION
## Summary

- Removes `t.Skip` from `TestProviderRateLimiter_ConcurrentAccess` in `internal/cli/rate_limiter_test.go`
- Root cause: `NewProviderRateLimiter` called `models.GetProviderDefaultRateLimit` for all providers, which returns 60 RPM for "openai" (the models package treats it as an obsolete provider falling through to the default case). At 60 RPM with burst=1, 200 operations would take ~200 seconds — the test appeared to deadlock but was actually just timing out.
- Fix: use the CLI-layer constants already defined in `rate_limiter.go` (`OpenAIDefaultRPM=3000`, `GeminiDefaultRPM=60`, `OpenRouterDefaultRPM=20`) as the primary lookup in `NewProviderRateLimiter`, falling back to `models.GetProviderDefaultRateLimit` for unknown providers. At 3000 RPM the concurrent test completes in ~4 seconds.
- The outer mutex deadlock described in `ratelimit.go`'s BUGFIX comment is a separate, already-merged fix; this PR resolves the timeout that caused the skip.

## Test plan

- [x] `go test -timeout 60s ./internal/cli/ -run TestProviderRateLimiter_ConcurrentAccess -v` passes in ~4s, not skipped
- [x] All existing `internal/cli` rate limiter tests pass
- [x] `internal/models` tests unaffected (no changes to models package)
- [x] Pre-existing failures in `auditlog`, `fileutil`, `thinktank` (file permission tests) are unrelated to this change

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured rate limiter configuration system with updated precedence hierarchy. CLI-level defaults now take priority over package defaults, while explicit overrides apply at the highest level. Enables more flexible control over provider-specific rate limiting.

* **Tests**
  * Enabled concurrent access testing for rate limiter functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->