### PR TITLE
fix(test): resolve TestProviderRateLimiter_ConcurrentAccess deadlock (closes #206)

### DIFF
--- a/internal/cli/rate_limiter.go
+++ b/internal/cli/rate_limiter.go
@@ -267,8 +267,14 @@ func (prl *ProviderRateLimiter) GetAllProviderStatuses() []ProviderStatus {
 	defer prl.mu.RUnlock()
 
 	var statuses []ProviderStatus
-	for provider := range prl.circuitBreakers {
-		statuses = append(statuses, prl.GetProviderStatus(provider))
+	for provider, cb := range prl.circuitBreakers {
+		statuses = append(statuses, ProviderStatus{
+			Provider:     provider,
+			Available:    cb.CanExecute(),
+			RateLimit:    prl.providerLimits[provider],
+			CircuitState: cb.GetState().String(),
+			FailureCount: cb.GetFailureCount(),
+		})
 	}
 
 	return statuses


### PR DESCRIPTION
## Summary

- **Re-entrant read lock** in `GetAllProviderStatuses`: held `prl.mu.RLock()` then called `GetProviderStatus` which also acquired `prl.mu.RLock()`. Under write contention Go's `RWMutex` blocks new readers when a writer waits, causing deadlock. Fixed by inlining the status struct build without calling the public method.

- **Token bucket starvation**: test used `context.Background()` with `OpenRouterDefaultRPM=20` (≈1 token/3s). 200 operations = ~600s minimum — effectively a hang. Fixed by overriding the openai RPM to 6000 in the test and adding a 10s context deadline so any future deadlock fails fast with a clear error.

## Test plan

- [x] `TestProviderRateLimiter_ConcurrentAccess` passes in ~2s with `-race`
- [x] All rate limiter and circuit breaker tests pass
- [x] `go test -race -count=1 ./...` completes without timeout (pre-existing unrelated failures in auditlog/fileutil/thinktank from root-process permission tests remain unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved rate limiter performance by optimizing provider status retrieval to eliminate redundant locking operations.
  
* **Tests**
  * Enhanced concurrent rate limiter test coverage with proper timeout guards and improved reliability verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->