### PR TITLE
fix: add CI job to satisfy branch protection check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,12 @@ name: CI
 on: [push, pull_request]
 
 jobs:
+  CI:
+    runs-on: ubuntu-latest
+    steps:
+      - name: CI check
+        run: echo "CI check passed"
+
   test:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,13 @@ on: [push, pull_request]
 jobs:
   CI:
     runs-on: ubuntu-latest
+    needs: test
     steps:
       - name: CI check
-        run: echo "CI check passed"
+        run: |
+          # CI job serves as the branch protection check
+          # It depends on the test job to ensure tests pass
+          echo "All required checks passed"
 
   test:
     runs-on: ubuntu-latest
@@ -55,7 +59,7 @@ jobs:
   security:
     if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    needs: test
+    needs: CI
     steps:
     - uses: actions/checkout@v4
     - name: Set up Go


### PR DESCRIPTION
This PR adds a CI job to the ci.yml workflow to satisfy the branch protection rule that requires a status check named 'CI'. The existing jobs are named 'test' and 'security', which don't satisfy the requirement.

Without this fix, merging PR #211 fails with: 'Required status check CI is expected.'

This is a minimal fix to make the branch protection happy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new CI check step to the continuous integration workflow to serve as an additional pre-test validation.
  * Adjusted the pipeline order so the security check now runs after the new CI check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->