### PR TITLE
ci: normalize merge gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,18 @@
-name: CI
+name: Quality Checks
 on: [push, pull_request]
 
 jobs:
-  CI:
+  merge-gate:
     runs-on: ubuntu-latest
     needs: test
+    if: always()
     steps:
-      - name: CI check
+      - name: Check all jobs passed
         run: |
-          # CI job serves as the branch protection check
-          # It depends on the test job to ensure tests pass
-          echo "All required checks passed"
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]] || \
+             [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            exit 1
+          fi
 
   test:
     runs-on: ubuntu-latest
@@ -59,7 +61,7 @@ jobs:
   security:
     if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    needs: CI
+    needs: merge-gate
     steps:
     - uses: actions/checkout@v4
     - name: Set up Go


### PR DESCRIPTION
## Why This Matters
- Problem: branch protection depended on a legacy `CI` check name that only echoed success, which made the required gate less explicit and easier to misread when upstream jobs failed.
- Value: this PR gives reviewers and branch protection one stable `merge-gate` verdict that always runs and fails closed when required work does not pass.
- Why now: the repo already depends on CI as a merge contract, so naming and result semantics should match the policy we actually enforce.
- Issue: none linked; this is CI hygiene / branch-protection normalization.

## Trade-offs / Risks
- Value gained: clearer required-check semantics, fewer skipped-gate surprises, and a dependency graph that matches branch protection.
- Cost / risk incurred: the workflow YAML becomes slightly more explicit and keeps one more shell guard in the gate job.
- Why this is still the right trade: the extra lines buy a deterministic merge verdict, which is exactly what the required check exists for.
- Reviewer watch-outs: the gate intentionally treats `failure` and `cancelled` as blocking results; `security` remains main-branch-only.

## What Changed
This PR renames the workflow-level merge contract from a vague `CI` pass-through job to an explicit `merge-gate` job, makes that gate run with `if: always()`, and fails the gate when upstream required work does not complete successfully.

### Base Branch
```mermaid
graph TD
  PR[push / pull_request] --> test[test job]
  test --> CI[CI job]
  CI --> security[security job on main only]
  CI --> BP[branch protection check named CI]
```

### This PR
```mermaid
graph TD
  PR[push / pull_request] --> test[test job]
  test --> gate[merge-gate job]
  gate --> security[security job on main only]
  gate --> BP[branch protection check named merge-gate]
```

### Architecture / State Change
```mermaid
stateDiagram-v2
  [*] --> test_result
  test_result --> gate_runs: always()
  gate_runs --> mergeable: test == success
  gate_runs --> blocked: test == failure or cancelled
```

Why this is better:
- reviewers can see the required check name and the gate logic in one place
- branch protection now depends on a job whose name matches its actual purpose
- failures no longer rely on a skipped upstream dependency to communicate the merge verdict

<details>
<summary>Intent Reference</summary>

## Intent Reference
- Intent: normalize the repo onto a stable required merge gate instead of a legacy pass-through `CI` job name.
- Source: PR diff and current branch-protection behavior; no separate issue was linked.

</details>

<details>
<summary>Changes</summary>

## Changes
- renamed workflow display name from `CI` to `Quality Checks`
- renamed the top-level gate job from `CI` to `merge-gate`
- added `if: always()` plus explicit failure/cancelled checks in the gate step
- updated `security` to depend on `merge-gate`

</details>

<details>
<summary>Acceptance Criteria</summary>

## Acceptance Criteria
- [x] expose a stable required check named `merge-gate`
- [x] ensure the gate always runs and fails when required upstream work fails or is cancelled
- [x] keep downstream workflow dependencies aligned with the renamed gate

</details>

<details>
<summary>Alternatives Considered</summary>

## Alternatives Considered
### Option A — Do nothing
- Upside: zero workflow churn.
- Downside: keep the legacy `CI` naming mismatch and rely on less explicit failure signaling.
- Why rejected: the whole point of a merge gate is to be obvious and deterministic.

### Option B — Rename the check only
- Upside: smaller diff.
- Downside: still leaves the gate as a pass-through echo job without `if: always()` semantics.
- Why rejected: clearer naming without clearer behavior only solves half the problem.

### Option C — Current approach
- Upside: explicit naming plus deterministic gate behavior.
- Downside: slightly more YAML and shell logic.
- Why chosen: it aligns the workflow graph, branch protection, and reviewer expectations.

</details>

<details>
<summary>Manual QA</summary>

## Manual QA
- `actionlint .github/workflows/ci.yml`
- Reviewed the diff to confirm `merge-gate` is the stable required job and `security` now depends on it.
- Verified GitHub Actions is green for `test` and `merge-gate` on this PR.

Expected result:
- `actionlint` passes locally
- PR checks remain green with `merge-gate` as the stable top-level verdict

</details>

<details>
<summary>Walkthrough</summary>

## Walkthrough
- Renderer: Terminal walkthrough
- Artifact: https://github.com/misty-step/thinktank/pull/229#issuecomment-4032226754
- Claim: this PR makes `merge-gate` the single stable branch-protection verdict for the repo.
- Before / After scope: `.github/workflows/ci.yml` gate naming, execution semantics, and downstream dependency wiring.
- Persistent verification: GitHub Actions `test`, GitHub Actions `merge-gate`, and local `actionlint .github/workflows/ci.yml`
- Residual gap: I did not locally simulate every GitHub-hosted result permutation.

</details>

<details>
<summary>Before / After</summary>

## Before / After
- Before: the repo exposed a required `CI` job that mostly acted as a pass-through label and could be harder to reason about when upstream work failed.
- After: the repo exposes an explicit `merge-gate` job that always runs, publishes one stable verdict, and blocks on failed/cancelled upstream work.
- Screenshots: not needed; this is an internal CI-only change.

</details>

<details>
<summary>Test Coverage</summary>

## Test Coverage
- Existing protection: GitHub Actions `test` and `merge-gate`
- Local check run in this stewardship pass: `actionlint .github/workflows/ci.yml`
- Gap: no dedicated unit test harness for GitHub Actions expressions; confidence comes from static linting plus green PR checks.

</details>

<details>
<summary>Merge Confidence</summary>

## Merge Confidence
- Confidence level: high
- Strongest evidence: green GitHub Actions checks on the PR, zero open review threads/comments requiring action, and a clean local `actionlint` run.
- Remaining uncertainty: merge-gate behavior is still validated indirectly through GitHub Actions semantics rather than a local simulator.
- What could still go wrong after merge: a future workflow edit could change `needs` behavior without updating the gate logic, but this PR itself is narrow and mechanically verified.

</details>
