### PR TITLE
ci: add workflow_dispatch trigger to Quality Checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: Quality Checks
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   merge-gate:


### PR DESCRIPTION
## What Changed

Adds `workflow_dispatch` to the Quality Checks workflow trigger list.

## Why This Matters

PR #234 (release 4.0.0) has `merge-gate` stuck as "expected" because release-please pushed a new commit using `GITHUB_TOKEN`, which doesn't trigger workflows (GitHub's anti-recursion guard). The CI that ran successfully was against the *previous* SHA, so GitHub doesn't count it.

Without `workflow_dispatch`, there's no way to manually re-trigger CI for that branch. This one-line fix makes `gh workflow run "Quality Checks" --ref <branch>` work, unblocking any PR where bot pushes silently skip CI.

## Trade-offs / Risks

None. `workflow_dispatch` is additive — doesn't change existing push/PR triggers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to support manual triggering in addition to automatic triggers on code changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->