### PR TITLE
chore: add lefthook.yml for post-merge reinstall

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,17 @@
+post-merge:
+  commands:
+    reinstall:
+      run: |
+        echo "thinktank: reinstalling after pull..."
+        VERSION=$(git describe --tags --always 2>/dev/null || echo "dev")
+        COMMIT=$(git rev-parse --short HEAD)
+        BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+        LDFLAGS="-X github.com/misty-step/thinktank/internal/version.Version=${VERSION}"
+        LDFLAGS="${LDFLAGS} -X github.com/misty-step/thinktank/internal/version.Commit=${COMMIT}"
+        LDFLAGS="${LDFLAGS} -X github.com/misty-step/thinktank/internal/version.BuildDate=${BUILD_DATE}"
+        if go install -ldflags "${LDFLAGS}" ./cmd/thinktank/ 2>&1; then
+          echo "thinktank updated: $(thinktank --version)"
+        else
+          echo "thinktank install failed"
+          exit 1
+        fi


### PR DESCRIPTION
## Summary
- `core.hooksPath` points to `~/.git-hooks/` (lefthook dispatcher), so `.git/hooks/post-merge` was never executed
- Adds `lefthook.yml` with the post-merge reinstall command so it actually runs after pulls

## Test plan
- [x] Verified `lefthook run post-merge` executes successfully and reinstalls thinktank

🤖 Generated with [Claude Code](https://claude.com/claude-code)