### PR TITLE
feat: scaffold project-local /qa and /demo skills

### DIFF
--- a/.claude/skills/demo/SKILL.md
+++ b/.claude/skills/demo/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: thinktank-demo
+description: |
+  Generate demo artifacts for thinktank CLI. Terminal captures of bench
+  launches, artifact walkthroughs, dry-run output.
+  Use when: "make a demo", "demo this", "PR evidence", "record walkthrough".
+  Trigger: /demo.
+disable-model-invocation: true
+argument-hint: "[feature|PR-number] [--format txt|gif] [upload]"
+---
+
+# /demo
+
+Capture thinktank CLI in action. Terminal output captures by default;
+GIF recordings for README or launch artifacts.
+
+## Capture Methods
+
+| Feature | Method | Tool | Output |
+|---------|--------|------|--------|
+| Bench listing | Output capture | script/redirect | `.txt` |
+| Bench inspection | Output capture | script/redirect | `.txt` |
+| Dry-run | Output capture | script/redirect | `.txt` |
+| Full research run | Output capture + artifact tree | script/redirect | `.txt` |
+| Full review run | Output capture + artifact tree | script/redirect | `.txt` |
+| Any CLI flow | Terminal GIF | asciinema + agg | `.gif` |
+
+## Workflow: Planner -> Implementer -> Critic
+
+### 1. Plan
+
+Identify what to demo based on the PR or feature:
+
+- What changed? (read the diff or PR description)
+- Which commands show the change? (before -> after)
+- What artifacts prove it worked?
+
+Build a shot list:
+
+| # | Command | Shows | Before State | After State |
+|---|---------|-------|-------------|------------|
+
+### 2. Capture
+
+**Output capture (default):**
+
+```bash
+mkdir -p /tmp/demo-thinktank
+mix escript.build
+
+# Capture command output with exit code
+{
+  echo "$ ./thinktank [command] [args]"
+  ./thinktank [command] [args] 2>&1
+  echo ""
+  echo "Exit code: $?"
+} > /tmp/demo-thinktank/01-feature-name.txt
+```
+
+**Artifact tree capture:**
+
+```bash
+OUTPUT=$(ls -td /tmp/thinktank-* | head -1)
+{
+  echo "Artifact directory: $OUTPUT"
+  echo ""
+  find "$OUTPUT" -type f | sort
+  echo ""
+  echo "=== contract.json ==="
+  jq . "$OUTPUT/contract.json"
+  echo ""
+  echo "=== manifest.json ==="
+  jq . "$OUTPUT/manifest.json"
+} > /tmp/demo-thinktank/02-artifacts.txt
+```
+
+**Terminal GIF (for README or launch):**
+
+```bash
+# Record terminal session
+asciinema rec /tmp/demo-thinktank/session.cast \
+  --command "./thinktank benches list && ./thinktank research 'analyze' --dry-run"
+
+# Convert to GIF
+agg /tmp/demo-thinktank/session.cast /tmp/demo-thinktank/demo.gif \
+  --cols 100 --rows 30 --font-size 14
+```
+
+If asciinema/agg unavailable, use script + manual annotation:
+
+```bash
+script -q /tmp/demo-thinktank/session.txt ./demo-script.sh
+```
+
+Rules:
+- Every "after" has a paired "before" at the same viewport/command
+- Dry-run captures are free — prefer them for non-critical demos
+- Full run captures should show the artifact tree, not just stdout
+- Target: GIFs < 5MB, text captures < 50KB
+
+### 3. Critique
+
+Launch a **fresh subagent** (no context from the implementer) to review:
+
+- Does each capture show a meaningful delta (not just default state)?
+- Are before/after pairs present for claimed changes?
+- Is the text readable and the flow logical?
+- Do artifact trees match what the code should produce?
+- Are GIFs under 5MB with > 10 frames?
+
+### 4. Upload (if requested)
+
+```bash
+# Bundle evidence
+PR_NUM=123
+cd /tmp/demo-thinktank
+tar czf evidence.tar.gz *.txt *.gif 2>/dev/null
+
+# Create draft release and upload
+gh release create qa-evidence-pr-${PR_NUM} \
+  --draft \
+  --title "QA Evidence: PR #${PR_NUM}" \
+  --notes "Demo artifacts for PR #${PR_NUM}" \
+  /tmp/demo-thinktank/*.txt /tmp/demo-thinktank/*.gif 2>/dev/null
+
+# Comment on PR
+gh pr comment ${PR_NUM} --body "Demo evidence uploaded to draft release qa-evidence-pr-${PR_NUM}"
+```
+
+## Demo-Worthy Features
+
+| # | Feature | Safe? | Command |
+|---|---------|-------|---------|
+| 1 | Bench listing | Yes | `./thinktank benches list` |
+| 2 | Bench inspection | Yes | `./thinktank benches show research/default --full` |
+| 3 | Bench validation | Yes | `./thinktank benches validate` |
+| 4 | Dry-run research | Yes | `./thinktank research "query" --dry-run` |
+| 5 | Dry-run review | Yes | `./thinktank review --dry-run` |
+| 6 | Full research run | API call | `./thinktank research "query" --paths lib/` |
+| 7 | Full review run | API call | `./thinktank review --base main --head HEAD` |
+| 8 | JSON output | Yes | `./thinktank benches list --json` |
+| 9 | Error handling | Yes | `./thinktank benches show nonexistent` |
+
+Items marked "Yes" are safe (no API calls, no cost). Use these for routine demos.
+
+## Gotchas
+
+- **Rebuild before capture.** `mix escript.build` — stale binary ruins demos.
+- **Default-state evidence proves nothing.** Show the delta: before/after, or the specific feature in action.
+- **Self-grading is worthless.** The critic subagent must inspect artifacts cold (no shared context with the implementer).
+- **Full runs cost money.** Only capture full research/review runs when the demo specifically needs live agent output.
+- **Artifact paths have timestamps.** Use `ls -td /tmp/thinktank-* | head -1`, not hardcoded paths.
+- **GIFs from asciinema need agg.** If agg isn't installed, fall back to text captures. Don't produce broken GIFs.
+- **Never commit binary artifacts to the repo.** Upload to draft releases or keep in /tmp.

--- a/.claude/skills/demo/SKILL.md
+++ b/.claude/skills/demo/SKILL.md
@@ -11,13 +11,13 @@ argument-hint: "[feature|PR-number] [--format txt|gif] [upload]"
 
 # /demo
 
-Capture thinktank CLI in action. Terminal output captures by default;
-GIF recordings for README or launch artifacts.
+Capture thinktank CLI in action. Screenshots and GIFs are the default
+deliverable — text captures are raw data, not evidence.
 
 ## Workflow
 
 1. **Plan:** Read the diff. Identify which commands show the delta. Build a shot list.
-2. **Capture:** Execute — output capture for most commands, GIF for README-worthy flows.
+2. **Capture:** Execute — screenshot or GIF every command. Text logs are supplementary.
 3. **Critique:** Fresh subagent (no shared context) reviews artifacts cold.
 4. **Upload:** `gh release create --draft` + PR comment (if requested).
 

--- a/.claude/skills/demo/SKILL.md
+++ b/.claude/skills/demo/SKILL.md
@@ -14,33 +14,14 @@ argument-hint: "[feature|PR-number] [--format txt|gif] [upload]"
 Capture thinktank CLI in action. Terminal output captures by default;
 GIF recordings for README or launch artifacts.
 
-## Capture Methods
+## Workflow
 
-| Feature | Method | Tool | Output |
-|---------|--------|------|--------|
-| Bench listing | Output capture | script/redirect | `.txt` |
-| Bench inspection | Output capture | script/redirect | `.txt` |
-| Dry-run | Output capture | script/redirect | `.txt` |
-| Full research run | Output capture + artifact tree | script/redirect | `.txt` |
-| Full review run | Output capture + artifact tree | script/redirect | `.txt` |
-| Any CLI flow | Terminal GIF | asciinema + agg | `.gif` |
+1. **Plan:** Read the diff. Identify which commands show the delta. Build a shot list.
+2. **Capture:** Execute — output capture for most commands, GIF for README-worthy flows.
+3. **Critique:** Fresh subagent (no shared context) reviews artifacts cold.
+4. **Upload:** `gh release create --draft` + PR comment (if requested).
 
-## Workflow: Planner -> Implementer -> Critic
-
-### 1. Plan
-
-Identify what to demo based on the PR or feature:
-
-- What changed? (read the diff or PR description)
-- Which commands show the change? (before -> after)
-- What artifacts prove it worked?
-
-Build a shot list:
-
-| # | Command | Shows | Before State | After State |
-|---|---------|-------|-------------|------------|
-
-### 2. Capture
+## Capture
 
 **Output capture (default):**
 
@@ -79,7 +60,7 @@ OUTPUT=$(ls -td /tmp/thinktank-* | head -1)
 ```bash
 # Record terminal session
 asciinema rec /tmp/demo-thinktank/session.cast \
-  --command "./thinktank benches list && ./thinktank research 'analyze' --dry-run"
+  --command "./thinktank benches list && ./thinktank research 'analyze this' --dry-run"
 
 # Convert to GIF
 agg /tmp/demo-thinktank/session.cast /tmp/demo-thinktank/demo.gif \
@@ -92,38 +73,19 @@ If asciinema/agg unavailable, use script + manual annotation:
 script -q /tmp/demo-thinktank/session.txt ./demo-script.sh
 ```
 
-Rules:
-- Every "after" has a paired "before" at the same viewport/command
-- Dry-run captures are free — prefer them for non-critical demos
-- Full run captures should show the artifact tree, not just stdout
-- Target: GIFs < 5MB, text captures < 50KB
+Every "after" needs a paired "before". Dry-run captures are free — prefer them.
+Full run captures should show the artifact tree, not just stdout.
+Target: GIFs < 5MB, text captures < 50KB.
 
-### 3. Critique
-
-Launch a **fresh subagent** (no context from the implementer) to review:
-
-- Does each capture show a meaningful delta (not just default state)?
-- Are before/after pairs present for claimed changes?
-- Is the text readable and the flow logical?
-- Do artifact trees match what the code should produce?
-- Are GIFs under 5MB with > 10 frames?
-
-### 4. Upload (if requested)
+## Upload (if requested)
 
 ```bash
-# Bundle evidence
 PR_NUM=123
-cd /tmp/demo-thinktank
-tar czf evidence.tar.gz *.txt *.gif 2>/dev/null
-
-# Create draft release and upload
 gh release create qa-evidence-pr-${PR_NUM} \
   --draft \
   --title "QA Evidence: PR #${PR_NUM}" \
   --notes "Demo artifacts for PR #${PR_NUM}" \
   /tmp/demo-thinktank/*.txt /tmp/demo-thinktank/*.gif 2>/dev/null
-
-# Comment on PR
 gh pr comment ${PR_NUM} --body "Demo evidence uploaded to draft release qa-evidence-pr-${PR_NUM}"
 ```
 

--- a/.claude/skills/demo/SKILL.md
+++ b/.claude/skills/demo/SKILL.md
@@ -33,8 +33,9 @@ mix escript.build
 {
   echo "$ ./thinktank [command] [args]"
   ./thinktank [command] [args] 2>&1
+  rc=$?
   echo ""
-  echo "Exit code: $?"
+  echo "Exit code: $rc"
 } > /tmp/demo-thinktank/01-feature-name.txt
 ```
 
@@ -81,12 +82,12 @@ Target: GIFs < 5MB, text captures < 50KB.
 
 ```bash
 PR_NUM=123
-gh release create qa-evidence-pr-${PR_NUM} \
+gh release create demo-evidence-pr-${PR_NUM} \
   --draft \
-  --title "QA Evidence: PR #${PR_NUM}" \
+  --title "Demo Evidence: PR #${PR_NUM}" \
   --notes "Demo artifacts for PR #${PR_NUM}" \
   /tmp/demo-thinktank/*.txt /tmp/demo-thinktank/*.gif 2>/dev/null
-gh pr comment ${PR_NUM} --body "Demo evidence uploaded to draft release qa-evidence-pr-${PR_NUM}"
+gh pr comment ${PR_NUM} --body "Demo evidence uploaded to draft release demo-evidence-pr-${PR_NUM}"
 ```
 
 ## Demo-Worthy Features

--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: thinktank-qa
+description: |
+  QA for thinktank CLI. Run benches, verify artifacts, check exit codes.
+  Use when: "run QA", "test this", "verify the feature", "QA this PR".
+  Trigger: /qa.
+disable-model-invocation: true
+argument-hint: "[command|bench-id|PR-number]"
+---
+
+# /qa
+
+Verify thinktank CLI behavior: commands execute correctly, artifacts are
+well-formed, exit codes match expectations.
+
+## Prerequisites
+
+- Escript is built: `mix escript.build`
+- Working directory has a git repo (most commands need one)
+
+## Build
+
+```bash
+mix escript.build
+```
+
+Rebuild after any code change. If the build fails, that's a P0 — stop QA.
+
+## Critical Paths
+
+| # | Command | What to Check |
+|---|---------|---------------|
+| 1 | `./thinktank --help` | Exit 0, usage text includes `research`, `review`, `benches` |
+| 2 | `./thinktank --version` | Exit 0, prints `thinktank X.Y.Z` |
+| 3 | `./thinktank benches list` | Exit 0, lists `research/default` and `review/default` |
+| 4 | `./thinktank benches show research/default` | Exit 0, valid JSON with agents array |
+| 5 | `./thinktank benches show research/default --full` | Exit 0, JSON includes full agent specs |
+| 6 | `./thinktank benches validate` | Exit 0, no validation errors |
+| 7 | `./thinktank research "test" --dry-run` | Exit 0, prints resolved bench without launching agents |
+| 8 | `./thinktank review --dry-run` | Exit 0, prints resolved review bench |
+| 9 | `./thinktank benches show nonexistent` | Exit 7, prints error message to stderr |
+| 10 | `./thinktank research --dry-run --json` | Exit 0, stdout is valid JSON |
+
+## Interactive Flows (if PR touches these)
+
+| Flow | Steps |
+|------|-------|
+| Research run | `research "analyze logging" --paths lib/` — verify agents/ dir, task.md, contract.json, manifest.json |
+| Review run | `review --base main --head HEAD` — verify review/, agents/, plan artifacts |
+| Review eval | `review eval <prior-run-dir>` — verify replay produces fresh artifacts |
+| Repo config | Create `.thinktank/config.yml`, run with `--trust-repo-config` — verify custom bench loads |
+| JSON output | Add `--json` to any command — verify valid JSON envelope on stdout |
+
+**Full runs call live APIs.** Only run these when the PR touches engine, executor,
+or prompt code. Use `--dry-run` for everything else.
+
+## Artifact Validation
+
+After any full run, verify the output directory:
+
+```bash
+OUTPUT=$(ls -td /tmp/thinktank-* | head -1)
+
+# Required artifacts
+test -f "$OUTPUT/contract.json" && echo "contract.json: ok"
+test -f "$OUTPUT/task.md" && echo "task.md: ok"
+test -f "$OUTPUT/manifest.json" && echo "manifest.json: ok"
+
+# contract.json is valid JSON
+jq . "$OUTPUT/contract.json" > /dev/null && echo "contract.json: valid JSON"
+
+# manifest.json has expected fields
+jq '.bench_id, .status, .artifacts' "$OUTPUT/manifest.json"
+
+# Agent outputs exist
+ls "$OUTPUT/agents/"*.md 2>/dev/null && echo "agent outputs: ok"
+```
+
+## Evidence
+
+Evidence goes to `/tmp/qa-thinktank/`.
+
+```bash
+mkdir -p /tmp/qa-thinktank
+```
+
+Capture strategy (CLI tool — no browser):
+
+| What | How | File |
+|------|-----|------|
+| Command output | Redirect stdout+stderr | `cmd-{name}.txt` |
+| Exit codes | `echo $?` after each command | Inline in output files |
+| Artifact structure | `find $OUTPUT -type f` | `artifacts.txt` |
+| JSON validity | `jq . <file>` | Pass/fail in output |
+| Error cases | Run invalid commands | `errors.txt` |
+
+## Output
+
+```
+Status: PASS / FAIL
+
+Critical paths: 10/10 passed
+Artifact validation: ok / FAIL (details)
+Error handling: exits with correct codes
+Evidence: /tmp/qa-thinktank/
+
+Recommendation: ready to merge / needs fix
+```
+
+## Gotchas
+
+- **Rebuild before QA.** Stale escript is the #1 false failure — always `mix escript.build` first.
+- **Full runs cost money.** Only run research/review without `--dry-run` when the PR touches agent dispatch, prompts, or synthesis.
+- **Exit code 7 vs 1.** Input errors (bad args, unknown bench) exit 7. Runtime errors exit 1. Verify the distinction.
+- **JSON mode changes output shape.** `--json` wraps output in an envelope — test both human and JSON output if the PR touches formatting.
+- **Repo config is opt-in.** `.thinktank/config.yml` only loads with `--trust-repo-config`. Test both trusted and untrusted paths.
+- **Review planner is non-deterministic.** The marshal agent may select different reviewers each run. Validate structure, not exact agent list.
+- **Artifact paths contain timestamps.** Don't hardcode paths — use `ls -td /tmp/thinktank-* | head -1` to find the latest run.

--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -45,8 +45,8 @@ Rebuild after any code change. If the build fails, that's a P0 — stop QA.
 
 | Flow | Steps |
 |------|-------|
-| Research run | `research "analyze logging" --paths lib/` — verify agents/ dir, task.md, contract.json, manifest.json |
-| Review run | `review --base main --head HEAD` — verify review/, agents/, plan artifacts |
+| Research run | `research "analyze logging" --paths ./lib --dry-run` (or live) — verify agents/ dir, task.md, contract.json, manifest.json |
+| Review run | `review --base origin/main --head HEAD` — verify review/, agents/, plan artifacts |
 | Review eval | `review eval <prior-run-dir>` — verify replay produces fresh artifacts |
 | Repo config | Create `.thinktank/config.yml`, run with `--trust-repo-config` — verify custom bench loads |
 | JSON output | Add `--json` to any command — verify valid JSON envelope on stdout |
@@ -93,19 +93,6 @@ Capture strategy (CLI tool — no browser):
 | Artifact structure | `find $OUTPUT -type f` | `artifacts.txt` |
 | JSON validity | `jq . <file>` | Pass/fail in output |
 | Error cases | Run invalid commands | `errors.txt` |
-
-## Output
-
-```
-Status: PASS / FAIL
-
-Critical paths: 10/10 passed
-Artifact validation: ok / FAIL (details)
-Error handling: exits with correct codes
-Evidence: /tmp/qa-thinktank/
-
-Recommendation: ready to merge / needs fix
-```
 
 ## Gotchas
 

--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -70,7 +70,7 @@ test -f "$OUTPUT/manifest.json" && echo "manifest.json: ok"
 jq . "$OUTPUT/contract.json" > /dev/null && echo "contract.json: valid JSON"
 
 # manifest.json has expected fields
-jq '.bench_id, .status, .artifacts' "$OUTPUT/manifest.json"
+jq '.bench, .status, .artifacts' "$OUTPUT/manifest.json"
 
 # Agent outputs exist
 ls "$OUTPUT/agents/"*.md 2>/dev/null && echo "agent outputs: ok"

--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -39,7 +39,7 @@ Rebuild after any code change. If the build fails, that's a P0 — stop QA.
 | 7 | `./thinktank research "test" --dry-run` | Exit 0, prints resolved bench without launching agents |
 | 8 | `./thinktank review --dry-run` | Exit 0, prints resolved review bench |
 | 9 | `./thinktank benches show nonexistent` | Exit 7, prints error message to stderr |
-| 10 | `./thinktank research --dry-run --json` | Exit 0, stdout is valid JSON |
+| 10 | `./thinktank research "test" --dry-run --json` | Exit 0, stdout is valid JSON |
 
 ## Interactive Flows (if PR touches these)
 

--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -84,15 +84,18 @@ Evidence goes to `/tmp/qa-thinktank/`.
 mkdir -p /tmp/qa-thinktank
 ```
 
-Capture strategy (CLI tool — no browser):
+Text captures are raw data, not reviewer-facing evidence. Evidence is visual.
 
-| What | How | File |
-|------|-----|------|
-| Command output | Redirect stdout+stderr | `cmd-{name}.txt` |
+| Deliverable | Method | Format |
+|-------------|--------|--------|
+| Terminal screenshots | Screenshot each command + output | `.png` |
+| Terminal GIF | `asciinema rec` + `agg`, or `script` + screen capture | `.gif` |
+| Command log (raw data) | Redirect stdout+stderr | `cmd-{name}.txt` |
 | Exit codes | `echo $?` after each command | Inline in output files |
 | Artifact structure | `find $OUTPUT -type f` | `artifacts.txt` |
 | JSON validity | `jq . <file>` | Pass/fail in output |
-| Error cases | Run invalid commands | `errors.txt` |
+
+The PR comment must include screenshots or GIFs. Text tables are claims, not proof.
 
 ## Gotchas
 

--- a/.groom/review-scores.ndjson
+++ b/.groom/review-scores.ndjson
@@ -1,2 +1,3 @@
 {"date":"2026-04-01","pr":null,"correctness":9,"depth":8,"simplicity":10,"craft":9,"verdict":"ship"}
 {"date":"2026-04-02","pr":null,"correctness":9,"depth":8,"simplicity":10,"craft":9,"verdict":"ship"}
+{"date":"2026-04-02","pr":286,"correctness":9,"depth":8,"simplicity":8,"craft":8,"verdict":"ship"}

--- a/lib/thinktank/executor/agentic.ex
+++ b/lib/thinktank/executor/agentic.ex
@@ -308,8 +308,12 @@ defmodule Thinktank.Executor.Agentic do
         {:ok, %File.Stat{type: :directory}} ->
           walk_reject_symlinks!(path)
 
-        _ ->
+        {:ok, _} ->
           :ok
+
+        {:error, reason} ->
+          raise ArgumentError,
+                "agent_config validation failed at #{path}: #{:file.format_error(reason)}"
       end
     end)
   end

--- a/lib/thinktank/executor/agentic.ex
+++ b/lib/thinktank/executor/agentic.ex
@@ -292,13 +292,21 @@ defmodule Thinktank.Executor.Agentic do
         :ok
     end
 
-    base_dir
-    |> Path.join("**")
-    |> Path.wildcard(match_dot: true)
-    |> Enum.each(fn path ->
+    walk_reject_symlinks!(base_dir)
+  end
+
+  defp walk_reject_symlinks!(dir) do
+    dir
+    |> File.ls!()
+    |> Enum.each(fn entry ->
+      path = Path.join(dir, entry)
+
       case File.lstat(path) do
         {:ok, %File.Stat{type: :symlink}} ->
           raise ArgumentError, "agent_config must not contain symlinks: #{path}"
+
+        {:ok, %File.Stat{type: :directory}} ->
+          walk_reject_symlinks!(path)
 
         _ ->
           :ok


### PR DESCRIPTION
## Summary

- Scaffolds `.claude/skills/qa/SKILL.md` — CLI-focused QA covering 10 critical path commands, artifact validation, evidence capture via terminal output
- Scaffolds `.claude/skills/demo/SKILL.md` — terminal demo capture with safe/costly feature table, planner→implementer→critic workflow, draft release upload

Both override the global fallback stubs. `disable-model-invocation: true` (user-invoked only).

## Test plan

- [ ] `/qa` resolves to project-local skill (not global redirect)
- [ ] `/demo` resolves to project-local skill (not global redirect)
- [ ] QA critical paths table covers all major CLI commands
- [ ] Demo feature table distinguishes safe vs API-calling commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a demo workflow for producing CLI demo captures: shot planning, terminal evidence, artifact collection, GIF/TTY recordings with fallbacks, critique stage, and optional upload.
  * Added a QA workflow with mandatory rebuilds, command-output and exit-code checks, artifact presence/JSON validation, standardized evidence capture, and testing gotchas.
* **Bug Fixes**
  * Improved directory traversal to explicitly reject symlinks and surface filesystem errors during validation.
* **Chores**
  * Added a new review-score record entry for tracking assessment metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->