### PR TITLE
Fix review synthesis fallback in run result envelopes

### DIFF
--- a/.groom/review-scores.ndjson
+++ b/.groom/review-scores.ndjson
@@ -1,1 +1,2 @@
 {"date":"2026-04-01","pr":null,"correctness":9,"depth":8,"simplicity":10,"craft":9,"verdict":"ship"}
+{"date":"2026-04-02","pr":null,"correctness":9,"depth":8,"simplicity":10,"craft":9,"verdict":"ship"}

--- a/lib/thinktank/run_store.ex
+++ b/lib/thinktank/run_store.ex
@@ -118,14 +118,22 @@ defmodule Thinktank.RunStore do
   defp content_type(_type, _file), do: "application/octet-stream"
 
   defp read_synthesis(output_dir, artifacts) do
-    case Enum.find(artifacts, &(&1["name"] == "synthesis")) do
-      nil ->
-        nil
+    artifacts
+    |> summary_artifact()
+    |> read_artifact(output_dir)
+  end
 
-      %{"file" => file} ->
-        path = Path.join(output_dir, file)
-        if File.exists?(path), do: File.read!(path), else: nil
-    end
+  defp summary_artifact(artifacts) do
+    Enum.find_value(["synthesis", "review", "summary"], fn name ->
+      Enum.find(artifacts, &(&1["name"] == name))
+    end)
+  end
+
+  defp read_artifact(nil, _output_dir), do: nil
+
+  defp read_artifact(%{"file" => file}, output_dir) do
+    path = Path.join(output_dir, file)
+    if File.exists?(path), do: File.read!(path), else: nil
   end
 
   defp resolve_artifact_path(output_dir, filename) do

--- a/test/thinktank/cli_test.exs
+++ b/test/thinktank/cli_test.exs
@@ -5,8 +5,6 @@ defmodule Thinktank.CLITest do
 
   alias Thinktank.CLI
 
-  @exit_codes CLI.exit_codes()
-
   defp unique_tmp_dir(prefix) do
     dir = Path.join(System.tmp_dir!(), "#{prefix}-#{System.unique_integer([:positive])}")
     File.rm_rf!(dir)

--- a/test/thinktank/config_test.exs
+++ b/test/thinktank/config_test.exs
@@ -100,6 +100,7 @@ defmodule Thinktank.ConfigTest do
   end
 
   test "does not expose legacy workflow aliases" do
+    assert Code.ensure_loaded?(Config)
     assert function_exported?(Config, :bench, 2)
     assert function_exported?(Config, :list_benches, 1)
     refute function_exported?(Config, :workflow, 2)

--- a/test/thinktank/engine_test.exs
+++ b/test/thinktank/engine_test.exs
@@ -82,6 +82,7 @@ defmodule Thinktank.EngineTest do
              )
 
     assert result.envelope.status == "complete"
+    assert result.envelope.synthesis =~ "Synthesized summary"
     assert File.exists?(Path.join(result.output_dir, "review.md"))
     assert File.read!(Path.join(result.output_dir, "review.md")) =~ "Synthesized summary"
     assert Enum.map(result.agents, & &1.name) == ["trace", "atlas", "proof"]

--- a/test/thinktank/run_store_test.exs
+++ b/test/thinktank/run_store_test.exs
@@ -120,6 +120,30 @@ defmodule Thinktank.RunStoreTest do
     assert json_artifact["content_type"] == "application/json"
   end
 
+  test "result_envelope inlines review summaries for review benches" do
+    output_dir = Path.join(unique_tmp_dir("thinktank-run-store-review-envelope"), "run")
+
+    contract = %RunContract{
+      bench_id: "review/default",
+      workspace_root: File.cwd!(),
+      input: %{input_text: "review this branch"},
+      artifact_dir: output_dir,
+      adapter_context: %{}
+    }
+
+    bench = %BenchSpec{id: "review/default", description: "Review", agents: ["trace"]}
+
+    RunStore.init_run(output_dir, contract, bench)
+    RunStore.record_agent_result(output_dir, "trace", "grounded finding", %{status: :ok})
+    RunStore.write_text_artifact(output_dir, "summary", "summary.md", "Review summary")
+    RunStore.write_text_artifact(output_dir, "review", "review.md", "Synthesized review")
+    RunStore.complete_run(output_dir, "complete")
+
+    envelope = RunStore.result_envelope(output_dir)
+
+    assert envelope.synthesis == "Synthesized review"
+  end
+
   test "result_envelope synthesis is nil when no synthesis artifact exists" do
     output_dir = Path.join(unique_tmp_dir("thinktank-run-store-no-synth"), "run")
 


### PR DESCRIPTION
## Summary
- update `RunStore.result_envelope/1` to inline synthesis text from `review` or `summary` artifacts when a `synthesis` artifact is absent
- add regression coverage for review benches so envelope synthesis includes the generated review summary
- make API export assertions deterministic in `ConfigTest` and remove an unused test module attribute in `CLITest`
- record the latest review score entry in `.groom/review-scores.ndjson`

## Testing
- `mix test`
- `mix compile --warnings-as-errors`
- `mix format --check-formatted`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved artifact handling to intelligently select from synthesis, review, or summary artifacts in order of preference, ensuring the system can adapt to different artifact configurations
  * Review bench results now automatically inline review summaries into result envelopes, providing more convenient access to synthesis information without requiring separate file lookups

<!-- end of auto-generated comment: release notes by coderabbit.ai -->