### PR TITLE
Add JSON output for benches validate

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.groom/review-scores.ndjson merge=union

--- a/.groom/review-scores.ndjson
+++ b/.groom/review-scores.ndjson
@@ -1,2 +1,2 @@
 {"date":"2026-04-01","pr":null,"correctness":9,"depth":8,"simplicity":10,"craft":9,"verdict":"ship"}
-{"date":"2026-04-02","pr":null,"correctness":9,"depth":8,"simplicity":9,"craft":9,"verdict":"ship"}
+{"date":"2026-04-02","pr":288,"correctness":9,"depth":8,"simplicity":9,"craft":9,"verdict":"ship"}

--- a/.groom/review-scores.ndjson
+++ b/.groom/review-scores.ndjson
@@ -1,1 +1,2 @@
 {"date":"2026-04-01","pr":null,"correctness":9,"depth":8,"simplicity":10,"craft":9,"verdict":"ship"}
+{"date":"2026-04-02","pr":null,"correctness":9,"depth":8,"simplicity":9,"craft":9,"verdict":"ship"}

--- a/backlog.d/004-add-json-output-for-benches-validate.md
+++ b/backlog.d/004-add-json-output-for-benches-validate.md
@@ -1,0 +1,37 @@
+# Add JSON Output For Benches Validate
+
+Priority: medium
+Status: done
+Estimate: S
+
+## Goal
+`thinktank benches validate --json` emits a machine-readable success payload and
+preserves structured JSON errors so agents and CI can validate config without
+scraping text output.
+
+## Non-Goals
+- Expanding `validate` into a discovery endpoint
+- Removing the legacy `workflows` CLI alias
+- Changing bench resolution or execution behavior outside the CLI boundary
+
+## Oracle
+- [x] `CLI.parse_args(["benches", "validate", "--json"])` yields
+      `action: :benches_validate` with `json: true`
+- [x] `thinktank benches validate --json` exits 0 and prints a JSON object with
+      fixed keys: `status` and `bench_count`
+- [x] `workflows validate --json` resolves to the same command shape while the
+      compatibility alias exists
+- [x] `thinktank benches validate` without `--json` remains human-readable
+- [x] Invalid trusted repo config emits the structured JSON error envelope on
+      `stderr` when `--json` is set and text errors otherwise
+
+## What Was Built
+- `Thinktank.CLI` now routes `benches validate` through a dedicated
+  `emit_benches_validate/2` helper so JSON and text output share the same
+  command path.
+- `--json` success output is intentionally minimal:
+  `%{"status" => "ok", "bench_count" => n}`.
+- CLI tests now cover success output, text fallback, alias execution parity, and
+  JSON/text error behavior for invalid trusted repo config.
+- Integration coverage now asserts the fixed `validate --json` success contract
+  alongside the existing discovery-path checks.

--- a/lib/thinktank/cli.ex
+++ b/lib/thinktank/cli.ex
@@ -113,7 +113,10 @@ defmodule Thinktank.CLI do
   def execute({:ok, %{action: :benches_validate} = command}) do
     case load_config(command) do
       {:ok, config} ->
-        IO.puts("Validated #{length(Config.list_benches(config))} benches")
+        config
+        |> Config.list_benches()
+        |> emit_benches_validate(command)
+
         @exit_codes.success
 
       {:error, reason} ->
@@ -434,6 +437,21 @@ defmodule Thinktank.CLI do
     Enum.each(benches, fn bench ->
       IO.puts("#{bench.id}\t#{bench.description}")
     end)
+  end
+
+  defp emit_benches_validate(benches, %{json: true}) do
+    payload = %{
+      status: "ok",
+      bench_count: length(benches)
+    }
+
+    payload
+    |> Jason.encode!()
+    |> IO.puts()
+  end
+
+  defp emit_benches_validate(benches, _command) do
+    IO.puts("Validated #{length(benches)} benches")
   end
 
   defp resolve_agents_payload(bench, _config, false), do: {:ok, bench.agents}

--- a/test/thinktank/cli_test.exs
+++ b/test/thinktank/cli_test.exs
@@ -5,6 +5,8 @@ defmodule Thinktank.CLITest do
 
   alias Thinktank.{CLI, Config}
 
+  @exit_codes CLI.exit_codes()
+
   defp unique_tmp_dir(prefix) do
     dir = Path.join(System.tmp_dir!(), "#{prefix}-#{System.unique_integer([:positive])}")
     File.rm_rf!(dir)

--- a/test/thinktank/cli_test.exs
+++ b/test/thinktank/cli_test.exs
@@ -3,7 +3,7 @@ defmodule Thinktank.CLITest do
 
   import ExUnit.CaptureIO
 
-  alias Thinktank.CLI
+  alias Thinktank.{CLI, Config}
 
   @exit_codes CLI.exit_codes()
 
@@ -196,10 +196,88 @@ defmodule Thinktank.CLITest do
 
   test "parses bench management commands and legacy workflows alias" do
     assert {:ok, %{action: :benches_list}} = CLI.parse_args(["benches", "list"])
-    assert {:ok, %{action: :benches_validate}} = CLI.parse_args(["workflows", "validate"])
+
+    assert {:ok, %{action: :benches_validate, json: true}} =
+             CLI.parse_args(["workflows", "validate", "--json"])
 
     assert {:ok, %{action: :benches_show, bench_id: "review/default"}} =
              CLI.parse_args(["workflows", "show", "review/default"])
+  end
+
+  test "benches validate prints JSON when --json is requested" do
+    {:ok, config} = Config.load()
+    expected_count = length(Config.list_benches(config))
+
+    {:ok, command} = CLI.parse_args(["benches", "validate", "--json"])
+
+    output =
+      capture_io(fn ->
+        assert CLI.execute({:ok, command}) == @exit_codes.success
+      end)
+
+    assert {:ok, decoded} = Jason.decode(String.trim(output))
+    assert decoded == %{"status" => "ok", "bench_count" => expected_count}
+  end
+
+  test "benches validate prints a human summary unless --json is requested" do
+    {:ok, config} = Config.load()
+    expected_count = length(Config.list_benches(config))
+
+    {:ok, command} = CLI.parse_args(["benches", "validate"])
+
+    output =
+      capture_io(fn ->
+        assert CLI.execute({:ok, command}) == @exit_codes.success
+      end)
+
+    assert output == "Validated #{expected_count} benches\n"
+  end
+
+  test "workflows validate prints the same JSON contract while the alias exists" do
+    {:ok, config} = Config.load()
+    expected_count = length(Config.list_benches(config))
+
+    {:ok, command} = CLI.parse_args(["workflows", "validate", "--json"])
+
+    output =
+      capture_io(fn ->
+        assert CLI.execute({:ok, command}) == @exit_codes.success
+      end)
+
+    assert {:ok, decoded} = Jason.decode(String.trim(output))
+    assert decoded == %{"status" => "ok", "bench_count" => expected_count}
+  end
+
+  test "benches validate emits structured JSON errors for invalid trusted repo config" do
+    in_tmp_repo_config("[]\n", fn ->
+      assert {:ok, command} =
+               CLI.parse_args(["benches", "validate", "--trust-repo-config", "--json"])
+
+      stderr =
+        capture_io(:stderr, fn ->
+          assert CLI.execute({:ok, command}) == @exit_codes.input_error
+        end)
+
+      assert {:ok, decoded} = Jason.decode(String.trim(stderr))
+      assert decoded["error"]["code"] == "run_error"
+      assert decoded["error"]["message"] =~ "must contain a YAML mapping"
+      assert decoded["error"]["details"] == %{}
+      assert decoded["output_dir"] == nil
+    end)
+  end
+
+  test "benches validate emits text errors without --json" do
+    in_tmp_repo_config("[]\n", fn ->
+      assert {:ok, command} = CLI.parse_args(["benches", "validate", "--trust-repo-config"])
+
+      stderr =
+        capture_io(:stderr, fn ->
+          assert CLI.execute({:ok, command}) == @exit_codes.input_error
+        end)
+
+      assert stderr =~ "Error: config file"
+      assert stderr =~ "must contain a YAML mapping"
+    end)
   end
 
   test "returns :needs_stdin when no research input is provided" do

--- a/test/thinktank/integration/agent_contract_test.exs
+++ b/test/thinktank/integration/agent_contract_test.exs
@@ -1,7 +1,7 @@
 defmodule Thinktank.Integration.AgentContractTest do
   @moduledoc """
   Integration tests verifying the agent discovery contract:
-  list benches (JSON) -> pick one -> show it (JSON, full) -> verify schema.
+  validate benches (JSON) -> list benches (JSON) -> pick one -> show it (JSON, full).
   Also tests structured error envelope output.
   """
 
@@ -14,6 +14,21 @@ defmodule Thinktank.Integration.AgentContractTest do
   @exit_codes CLI.exit_codes()
 
   describe "agent discovery path" do
+    test "validate benches exposes a machine-readable success payload" do
+      {:ok, validate_cmd} = CLI.parse_args(["benches", "validate", "--json"])
+
+      validate_output =
+        capture_io(fn ->
+          assert CLI.execute({:ok, validate_cmd}) == @exit_codes.success
+        end)
+
+      {:ok, validate_payload} = Jason.decode(String.trim(validate_output))
+      assert validate_payload["status"] == "ok"
+      assert is_integer(validate_payload["bench_count"])
+      assert validate_payload["bench_count"] > 0
+      assert Map.keys(validate_payload) |> Enum.sort() == ["bench_count", "status"]
+    end
+
     test "list benches, pick one, show full spec — all JSON" do
       # Step 1: list benches as JSON
       {:ok, list_cmd} = CLI.parse_args(["benches", "list", "--json"])


### PR DESCRIPTION
## Summary
- route `benches validate` through a dedicated emitter so JSON and text output share one code path
- return a minimal machine-readable success payload for `--json` with `status` and `bench_count`
- add CLI and integration coverage for JSON/text output, structured error handling, and `workflows validate --json` alias parity
- record and close the backlog item for this change

## Testing
- `mix format`
- `mix test`
- `mix compile --warnings-as-errors`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `benches validate` now supports `--json`, returning a stable JSON success payload with `status` and `bench_count`; `workflows validate` mirrors this behavior. Plain-text output unchanged when `--json` is omitted.

* **Tests**
  * Added CLI and integration tests asserting JSON/text success contracts and JSON-formatted error envelopes for invalid configs.

* **Chores**
  * Added review metadata entry and merge attribute for that file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->