### PR TITLE
test(e2e): add escript smoke suite with hermetic fake-pi

### DIFF
--- a/.groom/review-scores.ndjson
+++ b/.groom/review-scores.ndjson
@@ -6,3 +6,4 @@
 {"date":"2026-04-08","pr":null,"correctness":9,"depth":8,"simplicity":9,"craft":9,"verdict":"ship","providers":["codex"]}
 {"date":"2026-04-08","pr":null,"correctness":9,"depth":9,"simplicity":9,"craft":9,"verdict":"ship","providers":["codex"]}
 {"date":"2026-04-08","pr":null,"correctness":9,"depth":9,"simplicity":9,"craft":9,"verdict":"ship","providers":["thinktank","codex"]}
+{"date":"2026-04-14","pr":289,"correctness":9,"depth":8,"simplicity":8,"craft":9,"verdict":"ship","providers":["claude","codex","thinktank"]}

--- a/backlog.d/007-add-cli-e2e-smoke-suite.md
+++ b/backlog.d/007-add-cli-e2e-smoke-suite.md
@@ -1,7 +1,7 @@
 # Add CLI E2E Smoke Suite
 
 Priority: high
-Status: in-progress
+Status: done
 Estimate: M
 
 ## Goal
@@ -13,10 +13,23 @@ Core ThinkTank flows are verified through the built escript in temporary workspa
 - Replacing focused unit or integration tests
 
 ## Oracle
-- [ ] CI runs at least one escript-backed smoke path for `research` or `review eval`
-- [ ] Smoke tests assert exit codes plus generated artifacts such as `contract.json`, `manifest.json`, and summary output
-- [ ] Smoke coverage includes one stdin-fed command and one saved-contract replay
-- [ ] The smoke suite completes in under 60 seconds locally
+- [x] CI runs at least one escript-backed smoke path for `research` or `review eval`
+- [x] Smoke tests assert exit codes plus generated artifacts such as `contract.json`, `manifest.json`, and summary output
+- [x] Smoke coverage includes one stdin-fed command and one saved-contract replay
+- [x] The smoke suite completes in under 60 seconds locally
 
 ## Notes
 Current tests cover module-level contracts well, but they stop short of the built binary path. This item closes the last-mile verification gap.
+
+## What Was Built
+- `test/thinktank/e2e/smoke_test.exs` — two `:e2e`-tagged tests: stdin-fed `research --json --no-synthesis` and `review eval` saved-contract replay. Both run against the built `./thinktank` binary with a fake `pi` on `$PATH`, asserting exit codes, JSON envelope shape, `contract.json` and `manifest.json` contents, and absence of live-API markers on stdout/stderr.
+- `test/support/fake_pi.ex` — shared `Thinktank.Test.FakePi` module (`with_fake_pi/2` + `subprocess_env/2`) that writes an executable fake `pi` script, mutates `PATH`, and yields a hermetic subprocess env (scrubs `OPENROUTER_API_KEY` and `THINKTANK_OPENROUTER_API_KEY`, disables muontrap). Now consumed by the existing integration test as well.
+- `test/support/workspace.ex` — `Thinktank.Test.Workspace` with `unique_tmp_dir/1` (auto-cleanup via `on_exit`), `git!/2`, and `init_git_repo!/1`. Replaces duplicated helpers across two test modules.
+- `mix.exs` — added `elixirc_paths/1` so `test/support` is compiled only under `MIX_ENV=test`.
+- `test/test_helper.exs` — `ExUnit.configure(exclude: [:e2e])` keeps the default `mix test` fast; smoke suite opts in via `--include e2e` or the Dagger gate.
+- `ci/src/thinktank_ci/main.py` — new `e2e_smoke` Dagger function that runs `mix escript.build` then executes the suite inside the `escript` cache lane; registered as a required `e2e-smoke` gate in `check/1`.
+- `lib/thinktank/cli.ex` — `IO.read(:stdio, :all)` → `:eof`. Surfaced by the smoke suite: the Elixir 1.19 deprecation warning for `:all` was leaking onto stdout and corrupting `--json` envelopes for piped-stdin invocations. Fixed at the root.
+
+### Workarounds / Deviations
+- Stdin is piped to the escript via `/bin/sh -c '... < stdin_file'` rather than `Port.open`. `System.cmd` does not accept stdin input, and `Port.open` cannot half-close stdin — sending `{port, :close}` closes the whole port and the escript's `IO.read(:stdio, :eof)` never unblocks. Shell redirection gives the child a real piped, EOF-terminated stdin matching production. Stdin scratch file lives in a sibling tmp dir, not inside the workspace-under-test.
+- Stderr is captured separately (redirected to a file) so JSON decoding only sees stdout. Stderr is independently scanned for `openrouter.ai` / `https://api.` sentinels as a defense-in-depth network-leak check.

--- a/backlog.d/007-add-cli-e2e-smoke-suite.md
+++ b/backlog.d/007-add-cli-e2e-smoke-suite.md
@@ -1,7 +1,7 @@
 # Add CLI E2E Smoke Suite
 
 Priority: high
-Status: ready
+Status: in-progress
 Estimate: M
 
 ## Goal

--- a/ci/src/thinktank_ci/main.py
+++ b/ci/src/thinktank_ci/main.py
@@ -170,6 +170,32 @@ class ThinktankCi:
         )
 
     @function
+    async def e2e_smoke(
+        self,
+        source: Annotated[
+            dagger.Directory,
+            DefaultPath("/"),
+            Ignore(SOURCE_IGNORE),
+            Doc("Repo source directory"),
+        ],
+    ) -> None:
+        """Build the escript and run the CLI e2e smoke suite."""
+        await (
+            _elixir_env(source, "test", "escript")
+            .with_exec(["mix", "escript.build"])
+            .with_exec(
+                [
+                    "mix",
+                    "test",
+                    "--include",
+                    "e2e",
+                    "test/thinktank/e2e/smoke_test.exs",
+                ]
+            )
+            .sync()
+        )
+
+    @function
     async def shell(
         self,
         source: Annotated[
@@ -301,6 +327,7 @@ for path in paths:
             await run_gate("coveralls", self.coveralls(source))
             await run_gate("dialyzer", self.dialyzer(source))
             await run_gate("escript", self.escript(source))
+            await run_gate("e2e-smoke", self.e2e_smoke(source))
 
         lines = ["ThinkTank CI Results", "=" * 40]
         passed = 0

--- a/lib/thinktank/cli.ex
+++ b/lib/thinktank/cli.ex
@@ -636,7 +636,7 @@ defmodule Thinktank.CLI do
       input =
         opts
         |> Keyword.get(:reader, &IO.read/2)
-        |> then(& &1.(:stdio, :all))
+        |> then(& &1.(:stdio, :eof))
         |> case do
           data when is_binary(data) -> String.trim(data)
           _ -> ""

--- a/mix.exs
+++ b/mix.exs
@@ -9,12 +9,16 @@ defmodule Thinktank.MixProject do
       version: @version,
       elixir: "~> 1.17",
       start_permanent: Mix.env() == :prod,
+      elixirc_paths: elixirc_paths(Mix.env()),
       deps: deps(),
       escript: escript(),
       dialyzer: [plt_add_apps: [:mix]],
       test_coverage: [tool: ExCoveralls, summary: [threshold: 87]]
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 
   def application do
     [

--- a/test/support/fake_pi.ex
+++ b/test/support/fake_pi.ex
@@ -36,12 +36,23 @@ defmodule Thinktank.Test.FakePi do
 
     original_path = System.get_env("PATH")
     original_mode = System.get_env("THINKTANK_TEST_PI_MODE")
-    new_path = "#{tmp}:#{original_path}"
+
+    new_path =
+      if original_path in [nil, ""] do
+        tmp
+      else
+        "#{tmp}:#{original_path}"
+      end
+
     System.put_env("PATH", new_path)
     System.put_env("THINKTANK_TEST_PI_MODE", mode)
 
     on_exit(fn ->
-      System.put_env("PATH", original_path || "")
+      if is_nil(original_path) do
+        System.delete_env("PATH")
+      else
+        System.put_env("PATH", original_path)
+      end
 
       if is_nil(original_mode) do
         System.delete_env("THINKTANK_TEST_PI_MODE")
@@ -104,7 +115,6 @@ defmodule Thinktank.Test.FakePi do
     done
 
     prompt_name="$(basename "${prompt_file#@}" .md)"
-    prompt="$(cat "${prompt_file#@}")"
 
     if [ "$mode" = "fail" ]; then
       echo "simulated failure"

--- a/test/support/fake_pi.ex
+++ b/test/support/fake_pi.ex
@@ -18,6 +18,8 @@ defmodule Thinktank.Test.FakePi do
 
   import ExUnit.Callbacks, only: [on_exit: 1]
 
+  alias Thinktank.Test.Workspace
+
   @type mode :: String.t()
   @type env :: %{
           required(:mode) => mode(),
@@ -26,7 +28,7 @@ defmodule Thinktank.Test.FakePi do
 
   @spec with_fake_pi(mode(), (env() -> any())) :: any()
   def with_fake_pi(mode, fun) when is_binary(mode) and is_function(fun, 1) do
-    tmp = unique_tmp_dir("thinktank-fake-pi")
+    tmp = Workspace.unique_tmp_dir("thinktank-fake-pi")
     pi_path = Path.join(tmp, "pi")
 
     File.write!(pi_path, script())
@@ -83,13 +85,6 @@ defmodule Thinktank.Test.FakePi do
     ]
 
     base ++ extra
-  end
-
-  defp unique_tmp_dir(prefix) do
-    dir = Path.join(System.tmp_dir!(), "#{prefix}-#{System.unique_integer([:positive])}")
-    File.rm_rf!(dir)
-    File.mkdir_p!(dir)
-    dir
   end
 
   defp script do

--- a/test/support/fake_pi.ex
+++ b/test/support/fake_pi.ex
@@ -1,0 +1,148 @@
+defmodule Thinktank.Test.FakePi do
+  @moduledoc """
+  Test helper that installs a fake `pi` binary on `PATH` and returns the
+  resolved environment for hermetic subprocess invocations.
+
+  Modes:
+    * `"success"`  — every prompt yields a stub response.
+    * `"degraded"` — `systems-*` prompts succeed, all others exit non-zero.
+    * `"fail"`     — every prompt exits non-zero.
+
+  When called inside an ExUnit test, mutations to `PATH` /
+  `THINKTANK_TEST_PI_MODE` are restored via `on_exit/1`. The callback
+  receives an `env` map describing the fake shim's `PATH` and mode, so
+  callers that need to launch external subprocesses (e.g. the built
+  escript) can thread the same configuration into `System.cmd/3` or
+  `Port.open/2` via `subprocess_env/2`.
+  """
+
+  import ExUnit.Callbacks, only: [on_exit: 1]
+
+  @type mode :: String.t()
+  @type env :: %{
+          required(:mode) => mode(),
+          required(:path) => String.t()
+        }
+
+  @spec with_fake_pi(mode(), (env() -> any())) :: any()
+  def with_fake_pi(mode, fun) when is_binary(mode) and is_function(fun, 1) do
+    tmp = unique_tmp_dir("thinktank-fake-pi")
+    pi_path = Path.join(tmp, "pi")
+
+    File.write!(pi_path, script())
+    File.chmod!(pi_path, 0o755)
+
+    original_path = System.get_env("PATH")
+    original_mode = System.get_env("THINKTANK_TEST_PI_MODE")
+    new_path = "#{tmp}:#{original_path}"
+    System.put_env("PATH", new_path)
+    System.put_env("THINKTANK_TEST_PI_MODE", mode)
+
+    on_exit(fn ->
+      System.put_env("PATH", original_path || "")
+
+      if is_nil(original_mode) do
+        System.delete_env("THINKTANK_TEST_PI_MODE")
+      else
+        System.put_env("THINKTANK_TEST_PI_MODE", original_mode)
+      end
+    end)
+
+    fun.(%{mode: mode, path: new_path})
+  end
+
+  @doc """
+  Assemble a hermetic env list for `System.cmd/3` or `Port.open/2`.
+
+  Given the env map yielded by `with_fake_pi/2`, returns a list of
+  `{name, value}` tuples that:
+
+    * puts the fake `pi` shim first on `PATH`,
+    * propagates the selected `THINKTANK_TEST_PI_MODE`,
+    * disables MuonTrap so the subprocess can run without a port wrapper,
+    * clears `MIX_ENV` so the escript does not inherit a dev/test env,
+    * scrubs every OpenRouter API-key variable (defense in depth: both
+      `OPENROUTER_API_KEY` and `THINKTANK_OPENROUTER_API_KEY` must be
+      empty so a live network call cannot be made even if one name is
+      missed elsewhere),
+    * passes through `HOME` so `Path.expand/1` and similar resolve.
+
+  Callers can pass `extra` entries to append or override values.
+  """
+  @spec subprocess_env(env(), [{String.t(), String.t() | nil}]) ::
+          [{String.t(), String.t() | nil}]
+  def subprocess_env(env, extra \\ []) when is_map(env) and is_list(extra) do
+    base = [
+      {"PATH", env.path},
+      {"THINKTANK_TEST_PI_MODE", env.mode},
+      {"OPENROUTER_API_KEY", ""},
+      {"THINKTANK_OPENROUTER_API_KEY", ""},
+      {"THINKTANK_DISABLE_MUONTRAP", "1"},
+      {"MIX_ENV", nil},
+      {"HOME", System.get_env("HOME") || ""}
+    ]
+
+    base ++ extra
+  end
+
+  defp unique_tmp_dir(prefix) do
+    dir = Path.join(System.tmp_dir!(), "#{prefix}-#{System.unique_integer([:positive])}")
+    File.rm_rf!(dir)
+    File.mkdir_p!(dir)
+    dir
+  end
+
+  defp script do
+    """
+    #!/bin/sh
+    mode="${THINKTANK_TEST_PI_MODE:-success}"
+    prev=""
+    prompt_file=""
+
+    for arg in "$@"; do
+      if [ "$prev" = "-p" ]; then
+        prompt_file="$arg"
+        break
+      fi
+
+      prev="$arg"
+    done
+
+    prompt_name="$(basename "${prompt_file#@}" .md)"
+    prompt="$(cat "${prompt_file#@}")"
+
+    if [ "$mode" = "fail" ]; then
+      echo "simulated failure"
+      exit 1
+    fi
+
+    if [ "$mode" = "degraded" ]; then
+      case "$prompt_name" in
+        systems-*)
+          echo "Raw agent output"
+          exit 0
+          ;;
+        *)
+          echo "simulated failure"
+          exit 1
+          ;;
+      esac
+    fi
+
+    case "$prompt_name" in
+      marshal-*)
+      printf '%s\\n' \\
+        '{"summary":"Planner summary.",' \\
+        '"selected_agents":[{"name":"trace","brief":"Check correctness."}],' \\
+        '"synthesis_brief":"Use grounded evidence."}'
+      ;;
+      review-synth-*|research-synth-*)
+      echo "Synthesized summary"
+      ;;
+      *)
+      echo "Raw agent output"
+      ;;
+    esac
+    """
+  end
+end

--- a/test/support/workspace.ex
+++ b/test/support/workspace.ex
@@ -1,0 +1,43 @@
+defmodule Thinktank.Test.Workspace do
+  @moduledoc """
+  Shared workspace helpers for integration and e2e tests: hermetic tmp
+  directories and minimal git bootstrapping.
+
+  `unique_tmp_dir/1` registers an `on_exit/1` callback to remove the
+  directory at the end of the test so workspaces do not accumulate under
+  `System.tmp_dir!/0`.
+  """
+
+  import ExUnit.Callbacks, only: [on_exit: 1]
+
+  @spec unique_tmp_dir(String.t()) :: String.t()
+  def unique_tmp_dir(prefix) when is_binary(prefix) do
+    dir = Path.join(System.tmp_dir!(), "#{prefix}-#{System.unique_integer([:positive])}")
+    File.rm_rf!(dir)
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf(dir) end)
+    dir
+  end
+
+  @spec git!(String.t(), [String.t()]) :: :ok
+  def git!(cwd, args) when is_binary(cwd) and is_list(args) do
+    case System.cmd("git", args, cd: cwd, stderr_to_stdout: true, env: [{"LEFTHOOK", "0"}]) do
+      {_output, 0} ->
+        :ok
+
+      {output, status} ->
+        ExUnit.Assertions.flunk("git #{Enum.join(args, " ")} failed (#{status}): #{output}")
+    end
+  end
+
+  @spec init_git_repo!(String.t()) :: :ok
+  def init_git_repo!(cwd) when is_binary(cwd) do
+    git!(cwd, ["init"])
+    git!(cwd, ["config", "user.email", "thinktank@example.com"])
+    git!(cwd, ["config", "user.name", "ThinkTank Test"])
+    File.write!(Path.join(cwd, ".gitkeep"), "")
+    git!(cwd, ["add", "."])
+    git!(cwd, ["commit", "-m", "initial"])
+    :ok
+  end
+end

--- a/test/support/workspace.ex
+++ b/test/support/workspace.ex
@@ -19,8 +19,7 @@ defmodule Thinktank.Test.Workspace do
     dir
   end
 
-  @spec git!(String.t(), [String.t()]) :: :ok
-  def git!(cwd, args) when is_binary(cwd) and is_list(args) do
+  defp git!(cwd, args) when is_binary(cwd) and is_list(args) do
     case System.cmd("git", args, cd: cwd, stderr_to_stdout: true, env: [{"LEFTHOOK", "0"}]) do
       {_output, 0} ->
         :ok

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -5,4 +5,5 @@ System.put_env(
   Path.join(System.tmp_dir!(), "thinktank-test-logs-#{System.unique_integer([:positive])}")
 )
 
+ExUnit.configure(exclude: [:e2e])
 ExUnit.start()

--- a/test/thinktank/cli_test.exs
+++ b/test/thinktank/cli_test.exs
@@ -317,7 +317,7 @@ defmodule Thinktank.CLITest do
     assert {:ok, updated} =
              CLI.read_stdin(command,
                stdin_piped?: true,
-               reader: fn :stdio, :all -> "  inspect this branch  \n" end
+               reader: fn :stdio, :eof -> "  inspect this branch  \n" end
              )
 
     assert updated.input.input_text == "inspect this branch"

--- a/test/thinktank/e2e/smoke_test.exs
+++ b/test/thinktank/e2e/smoke_test.exs
@@ -117,6 +117,12 @@ defmodule Thinktank.E2E.SmokeTest do
         assert status == 0,
                "expected exit 0, got #{status}. stdout:\n#{stdout}\nstderr:\n#{stderr}"
 
+        refute stdout =~ "openrouter.ai",
+               "stdout leaked openrouter.ai reference:\n#{stdout}"
+
+        refute stdout =~ "https://api.",
+               "stdout leaked HTTPS api reference:\n#{stdout}"
+
         refute stderr =~ "openrouter.ai",
                "stderr leaked openrouter.ai reference:\n#{stderr}"
 

--- a/test/thinktank/e2e/smoke_test.exs
+++ b/test/thinktank/e2e/smoke_test.exs
@@ -1,0 +1,189 @@
+defmodule Thinktank.E2E.SmokeTest do
+  @moduledoc """
+  End-to-end smoke checks for the built `./thinktank` escript.
+
+  Verifies the two highest-value flows — `research --json` over stdin and
+  `review eval` against a saved contract — through the actual binary, with
+  a fake `pi` shim on `PATH` so no live OpenRouter calls are made.
+  """
+
+  use ExUnit.Case, async: false
+
+  @moduletag :e2e
+
+  alias Thinktank.Test.FakePi
+  alias Thinktank.Test.Workspace
+
+  @repo_root Path.expand("../../..", __DIR__)
+  @escript Path.join(@repo_root, "thinktank")
+
+  setup_all do
+    unless File.exists?(@escript) do
+      flunk("""
+      Built escript not found at #{@escript}.
+      Run `mix escript.build` before invoking the e2e smoke suite.
+      """)
+    end
+
+    :ok
+  end
+
+  describe "research --json over stdin" do
+    test "exits 0 and emits a complete run payload without contacting the network" do
+      FakePi.with_fake_pi("success", fn env ->
+        workspace = Workspace.unique_tmp_dir("thinktank-e2e-research")
+
+        {stdout, stderr, status} =
+          run_escript(
+            ["research", "--json", "--no-synthesis", "--agents", "systems"],
+            cd: workspace,
+            env: FakePi.subprocess_env(env),
+            input: "inspect this repo\n"
+          )
+
+        assert status == 0,
+               "expected exit 0, got #{status}. stdout:\n#{stdout}\nstderr:\n#{stderr}"
+
+        refute stdout =~ "openrouter.ai",
+               "stdout leaked openrouter.ai reference:\n#{stdout}"
+
+        refute stdout =~ "https://api.",
+               "stdout leaked HTTPS api reference:\n#{stdout}"
+
+        refute stderr =~ "openrouter.ai",
+               "stderr leaked openrouter.ai reference:\n#{stderr}"
+
+        refute stderr =~ "https://api.",
+               "stderr leaked HTTPS api reference:\n#{stderr}"
+
+        payload = decode_json!(stdout)
+
+        assert payload["bench"] == "research/default"
+        assert payload["status"] == "complete"
+        assert is_binary(payload["output_dir"])
+        assert is_binary(payload["started_at"])
+        assert is_binary(payload["completed_at"])
+        assert is_list(payload["artifacts"])
+        assert is_list(payload["agents"])
+
+        output_dir = payload["output_dir"]
+        contract_path = Path.join(output_dir, "contract.json")
+        manifest_path = Path.join(output_dir, "manifest.json")
+
+        assert File.exists?(contract_path), "missing contract.json at #{contract_path}"
+        assert File.exists?(manifest_path), "missing manifest.json at #{manifest_path}"
+
+        contract = decode_json!(File.read!(contract_path))
+        assert is_binary(contract["bench_id"])
+        assert is_binary(contract["workspace_root"])
+        assert is_map(contract["input"])
+        assert is_binary(contract["artifact_dir"])
+        assert is_map(contract["adapter_context"])
+
+        manifest = decode_json!(File.read!(manifest_path))
+        assert manifest["status"] == "complete"
+      end)
+    end
+  end
+
+  describe "review eval against a saved contract" do
+    test "exits 0 with a complete cases payload and per-case manifest" do
+      FakePi.with_fake_pi("success", fn env ->
+        workspace = Workspace.unique_tmp_dir("thinktank-e2e-review-workspace")
+        Workspace.init_git_repo!(workspace)
+
+        fixture_root = Workspace.unique_tmp_dir("thinktank-e2e-review-fixtures")
+        output_root = Path.join(Workspace.unique_tmp_dir("thinktank-e2e-review-output"), "runs")
+
+        contract = %{
+          "bench_id" => "review/default",
+          "workspace_root" => workspace,
+          "input" => %{"input_text" => "Review the current change"},
+          "artifact_dir" => Path.join([fixture_root, "case-001", "source-run"]),
+          "adapter_context" => %{}
+        }
+
+        contract_path = Path.join([fixture_root, "case-001", "contract.json"])
+        File.mkdir_p!(Path.dirname(contract_path))
+        File.write!(contract_path, Jason.encode!(contract))
+
+        {stdout, stderr, status} =
+          run_escript(
+            ["review", "eval", fixture_root, "--json", "--output", output_root],
+            cd: workspace,
+            env: FakePi.subprocess_env(env)
+          )
+
+        assert status == 0,
+               "expected exit 0, got #{status}. stdout:\n#{stdout}\nstderr:\n#{stderr}"
+
+        refute stderr =~ "openrouter.ai",
+               "stderr leaked openrouter.ai reference:\n#{stderr}"
+
+        refute stderr =~ "https://api.",
+               "stderr leaked HTTPS api reference:\n#{stderr}"
+
+        payload = decode_json!(stdout)
+        assert payload["status"] == "complete"
+        assert is_list(payload["cases"])
+        assert payload["cases"] != []
+
+        case_manifest = Path.join([Path.expand(output_root), "case-001", "manifest.json"])
+        assert File.exists?(case_manifest), "missing per-case manifest at #{case_manifest}"
+
+        manifest = decode_json!(File.read!(case_manifest))
+        assert manifest["status"] == "complete"
+      end)
+    end
+  end
+
+  # ─── helpers ──────────────────────────────────────────────────────────
+
+  # Runs the built escript and returns {stdout, stderr, status}. Stderr is
+  # captured to a sibling tmp file so JSON on stdout is never corrupted by
+  # log lines. The stdin scratch file (if any) is written outside the
+  # workspace-under-test so the assertions see a clean tree.
+  defp run_escript(args, opts) do
+    cd = Keyword.fetch!(opts, :cd)
+    env = Keyword.fetch!(opts, :env)
+    input = Keyword.get(opts, :input)
+
+    scratch_dir = Workspace.unique_tmp_dir("thinktank-e2e-scratch")
+    stderr_path = Path.join(scratch_dir, "stderr.log")
+
+    redirected = "2> #{shell_escape(stderr_path)}"
+
+    cmd =
+      case input do
+        nil ->
+          "exec #{shell_escape(@escript)} #{shell_args(args)} #{redirected}"
+
+        bin when is_binary(bin) ->
+          stdin_path = Path.join(scratch_dir, "stdin.txt")
+          File.write!(stdin_path, bin)
+
+          "exec #{shell_escape(@escript)} #{shell_args(args)}" <>
+            " < #{shell_escape(stdin_path)} #{redirected}"
+      end
+
+    {stdout, status} = System.cmd("/bin/sh", ["-c", cmd], cd: cd, env: env)
+    stderr = File.read!(stderr_path)
+    {stdout, stderr, status}
+  end
+
+  defp shell_args(args), do: Enum.map_join(args, " ", &shell_escape/1)
+
+  defp shell_escape(value) do
+    "'" <> String.replace(value, "'", "'\\''") <> "'"
+  end
+
+  defp decode_json!(text) do
+    case Jason.decode(String.trim(text)) do
+      {:ok, decoded} ->
+        decoded
+
+      {:error, error} ->
+        flunk("expected JSON output, got error #{inspect(error)}\nraw:\n#{text}")
+    end
+  end
+end

--- a/test/thinktank/integration/agent_contract_test.exs
+++ b/test/thinktank/integration/agent_contract_test.exs
@@ -10,111 +10,11 @@ defmodule Thinktank.Integration.AgentContractTest do
   import ExUnit.CaptureIO
 
   alias Thinktank.CLI
+  alias Thinktank.Test.FakePi
+  alias Thinktank.Test.Workspace
 
   @exit_codes CLI.exit_codes()
   @repo_root Path.expand("../../..", __DIR__)
-
-  defp unique_tmp_dir(prefix) do
-    dir = Path.join(System.tmp_dir!(), "#{prefix}-#{System.unique_integer([:positive])}")
-    File.rm_rf!(dir)
-    File.mkdir_p!(dir)
-    dir
-  end
-
-  defp git!(cwd, args) do
-    case System.cmd("git", args, cd: cwd, stderr_to_stdout: true, env: [{"LEFTHOOK", "0"}]) do
-      {_output, 0} -> :ok
-      {output, status} -> flunk("git #{Enum.join(args, " ")} failed (#{status}): #{output}")
-    end
-  end
-
-  defp init_git_repo_with_commit!(cwd) do
-    git!(cwd, ["init"])
-    git!(cwd, ["config", "user.email", "thinktank@example.com"])
-    git!(cwd, ["config", "user.name", "ThinkTank Test"])
-    File.write!(Path.join(cwd, ".gitkeep"), "")
-    git!(cwd, ["add", "."])
-    git!(cwd, ["commit", "-m", "initial"])
-  end
-
-  defp with_fake_pi(mode, fun) do
-    tmp = unique_tmp_dir("thinktank-fake-pi")
-    pi_path = Path.join(tmp, "pi")
-
-    File.write!(
-      pi_path,
-      """
-      #!/bin/sh
-      mode="${THINKTANK_TEST_PI_MODE:-success}"
-      prev=""
-      prompt_file=""
-
-      for arg in "$@"; do
-        if [ "$prev" = "-p" ]; then
-          prompt_file="$arg"
-          break
-        fi
-
-        prev="$arg"
-      done
-
-      prompt_name="$(basename "${prompt_file#@}" .md)"
-      prompt="$(cat "${prompt_file#@}")"
-
-      if [ "$mode" = "fail" ]; then
-        echo "simulated failure"
-        exit 1
-      fi
-
-      if [ "$mode" = "degraded" ]; then
-        case "$prompt_name" in
-          systems-*)
-            echo "Raw agent output"
-            exit 0
-            ;;
-          *)
-            echo "simulated failure"
-            exit 1
-            ;;
-        esac
-      fi
-
-      case "$prompt_name" in
-        marshal-*)
-        printf '%s\\n' \
-          '{"summary":"Planner summary.",' \
-          '"selected_agents":[{"name":"trace","brief":"Check correctness."}],' \
-          '"synthesis_brief":"Use grounded evidence."}'
-        ;;
-        review-synth-*|research-synth-*)
-        echo "Synthesized summary"
-        ;;
-        *)
-        echo "Raw agent output"
-        ;;
-      esac
-      """
-    )
-
-    File.chmod!(pi_path, 0o755)
-
-    original_path = System.get_env("PATH")
-    original_mode = System.get_env("THINKTANK_TEST_PI_MODE")
-    System.put_env("PATH", "#{tmp}:#{original_path}")
-    System.put_env("THINKTANK_TEST_PI_MODE", mode)
-
-    on_exit(fn ->
-      System.put_env("PATH", original_path || "")
-
-      if is_nil(original_mode) do
-        System.delete_env("THINKTANK_TEST_PI_MODE")
-      else
-        System.put_env("THINKTANK_TEST_PI_MODE", original_mode)
-      end
-    end)
-
-    fun.()
-  end
 
   describe "agent discovery path" do
     test "validate benches exposes a machine-readable success payload" do
@@ -206,8 +106,8 @@ defmodule Thinktank.Integration.AgentContractTest do
     end
 
     test "research can read stdin and expose output_dir and artifacts in JSON" do
-      with_fake_pi("success", fn ->
-        workspace = unique_tmp_dir("thinktank-agent-run-contract")
+      FakePi.with_fake_pi("success", fn _env ->
+        workspace = Workspace.unique_tmp_dir("thinktank-agent-run-contract")
 
         File.cd!(workspace, fn ->
           assert {:needs_stdin, command} =
@@ -216,7 +116,7 @@ defmodule Thinktank.Integration.AgentContractTest do
           assert {:ok, command} =
                    CLI.read_stdin(command,
                      stdin_piped?: true,
-                     reader: fn :stdio, :all -> "inspect this repo\n" end
+                     reader: fn :stdio, :eof -> "inspect this repo\n" end
                    )
 
           output =
@@ -252,8 +152,8 @@ defmodule Thinktank.Integration.AgentContractTest do
     end
 
     test "non-json run output includes the selected output directory" do
-      with_fake_pi("success", fn ->
-        workspace = unique_tmp_dir("thinktank-agent-run-text")
+      FakePi.with_fake_pi("success", fn _env ->
+        workspace = Workspace.unique_tmp_dir("thinktank-agent-run-text")
         output_root = Path.join(workspace, "captured-run")
 
         File.cd!(workspace, fn ->
@@ -279,8 +179,8 @@ defmodule Thinktank.Integration.AgentContractTest do
     end
 
     test "degraded run json exposes a typed top-level error" do
-      with_fake_pi("degraded", fn ->
-        workspace = unique_tmp_dir("thinktank-agent-run-degraded")
+      FakePi.with_fake_pi("degraded", fn _env ->
+        workspace = Workspace.unique_tmp_dir("thinktank-agent-run-degraded")
 
         File.cd!(workspace, fn ->
           assert {:ok, command} =
@@ -306,11 +206,11 @@ defmodule Thinktank.Integration.AgentContractTest do
     end
 
     test "review eval json exposes typed errors and aggregate artifacts" do
-      with_fake_pi("fail", fn ->
-        workspace = unique_tmp_dir("thinktank-agent-review-eval")
-        init_git_repo_with_commit!(workspace)
-        fixture_root = unique_tmp_dir("thinktank-agent-review-fixtures")
-        output_root = Path.join(unique_tmp_dir("thinktank-agent-review-output"), "runs")
+      FakePi.with_fake_pi("fail", fn _env ->
+        workspace = Workspace.unique_tmp_dir("thinktank-agent-review-eval")
+        Workspace.init_git_repo!(workspace)
+        fixture_root = Workspace.unique_tmp_dir("thinktank-agent-review-fixtures")
+        output_root = Path.join(Workspace.unique_tmp_dir("thinktank-agent-review-output"), "runs")
 
         contract = %{
           "bench_id" => "review/default",
@@ -362,11 +262,13 @@ defmodule Thinktank.Integration.AgentContractTest do
     end
 
     test "review eval text output includes the selected output directory" do
-      with_fake_pi("success", fn ->
-        workspace = unique_tmp_dir("thinktank-agent-review-eval-text")
-        init_git_repo_with_commit!(workspace)
-        fixture_root = unique_tmp_dir("thinktank-agent-review-text-fixtures")
-        output_root = Path.join(unique_tmp_dir("thinktank-agent-review-text-output"), "runs")
+      FakePi.with_fake_pi("success", fn _env ->
+        workspace = Workspace.unique_tmp_dir("thinktank-agent-review-eval-text")
+        Workspace.init_git_repo!(workspace)
+        fixture_root = Workspace.unique_tmp_dir("thinktank-agent-review-text-fixtures")
+
+        output_root =
+          Path.join(Workspace.unique_tmp_dir("thinktank-agent-review-text-output"), "runs")
 
         contract = %{
           "bench_id" => "review/default",

--- a/test/thinktank/review/eval_test.exs
+++ b/test/thinktank/review/eval_test.exs
@@ -2,35 +2,13 @@ defmodule Thinktank.Review.EvalTest do
   use ExUnit.Case, async: false
 
   alias Thinktank.{Error, Review.Eval, RunContract}
-
-  defp unique_tmp_dir(prefix) do
-    dir = Path.join(System.tmp_dir!(), "#{prefix}-#{System.unique_integer([:positive])}")
-    File.rm_rf!(dir)
-    File.mkdir_p!(dir)
-    dir
-  end
-
-  defp git!(cwd, args) do
-    case System.cmd("git", args, cd: cwd, stderr_to_stdout: true, env: [{"LEFTHOOK", "0"}]) do
-      {_output, 0} -> :ok
-      {output, status} -> flunk("git #{Enum.join(args, " ")} failed (#{status}): #{output}")
-    end
-  end
-
-  defp init_git_repo_with_commit!(cwd) do
-    git!(cwd, ["init"])
-    git!(cwd, ["config", "user.email", "thinktank@example.com"])
-    git!(cwd, ["config", "user.name", "ThinkTank Test"])
-    File.write!(Path.join(cwd, ".gitkeep"), "")
-    git!(cwd, ["add", "."])
-    git!(cwd, ["commit", "-m", "initial"])
-  end
+  alias Thinktank.Test.Workspace
 
   test "replays one or more frozen contract files" do
-    workspace = unique_tmp_dir("thinktank-review-eval-workspace")
-    init_git_repo_with_commit!(workspace)
-    fixture_root = unique_tmp_dir("thinktank-review-eval-fixtures")
-    output_root = Path.join(unique_tmp_dir("thinktank-review-eval-output"), "runs")
+    workspace = Workspace.unique_tmp_dir("thinktank-review-eval-workspace")
+    Workspace.init_git_repo!(workspace)
+    fixture_root = Workspace.unique_tmp_dir("thinktank-review-eval-fixtures")
+    output_root = Path.join(Workspace.unique_tmp_dir("thinktank-review-eval-output"), "runs")
 
     contract = %RunContract{
       bench_id: "review/default",
@@ -107,10 +85,12 @@ defmodule Thinktank.Review.EvalTest do
   end
 
   test "replays a historical contract with a removed bench_id through review/default" do
-    workspace = unique_tmp_dir("thinktank-review-eval-historical")
-    init_git_repo_with_commit!(workspace)
-    fixture_root = unique_tmp_dir("thinktank-review-eval-historical-fixtures")
-    output_root = Path.join(unique_tmp_dir("thinktank-review-eval-historical-output"), "runs")
+    workspace = Workspace.unique_tmp_dir("thinktank-review-eval-historical")
+    Workspace.init_git_repo!(workspace)
+    fixture_root = Workspace.unique_tmp_dir("thinktank-review-eval-historical-fixtures")
+
+    output_root =
+      Path.join(Workspace.unique_tmp_dir("thinktank-review-eval-historical-output"), "runs")
 
     contract = %RunContract{
       bench_id: "review/cerberus",
@@ -162,10 +142,12 @@ defmodule Thinktank.Review.EvalTest do
   end
 
   test "returns typed case and top-level errors when replay cases fail" do
-    workspace = unique_tmp_dir("thinktank-review-eval-failing")
-    init_git_repo_with_commit!(workspace)
-    fixture_root = unique_tmp_dir("thinktank-review-eval-failing-fixtures")
-    output_root = Path.join(unique_tmp_dir("thinktank-review-eval-failing-output"), "runs")
+    workspace = Workspace.unique_tmp_dir("thinktank-review-eval-failing")
+    Workspace.init_git_repo!(workspace)
+    fixture_root = Workspace.unique_tmp_dir("thinktank-review-eval-failing-fixtures")
+
+    output_root =
+      Path.join(Workspace.unique_tmp_dir("thinktank-review-eval-failing-output"), "runs")
 
     contract = %RunContract{
       bench_id: "review/default",
@@ -194,10 +176,12 @@ defmodule Thinktank.Review.EvalTest do
   end
 
   test "returns a typed degraded error when replay cases degrade without failing" do
-    workspace = unique_tmp_dir("thinktank-review-eval-degraded")
-    init_git_repo_with_commit!(workspace)
-    fixture_root = unique_tmp_dir("thinktank-review-eval-degraded-fixtures")
-    output_root = Path.join(unique_tmp_dir("thinktank-review-eval-degraded-output"), "runs")
+    workspace = Workspace.unique_tmp_dir("thinktank-review-eval-degraded")
+    Workspace.init_git_repo!(workspace)
+    fixture_root = Workspace.unique_tmp_dir("thinktank-review-eval-degraded-fixtures")
+
+    output_root =
+      Path.join(Workspace.unique_tmp_dir("thinktank-review-eval-degraded-output"), "runs")
 
     contract = %RunContract{
       bench_id: "review/default",
@@ -242,12 +226,14 @@ defmodule Thinktank.Review.EvalTest do
   end
 
   test "returns a typed degraded error when replay cases are mixed" do
-    success_workspace = unique_tmp_dir("thinktank-review-eval-mixed-success")
-    failing_workspace = unique_tmp_dir("thinktank-review-eval-mixed-failing")
-    init_git_repo_with_commit!(success_workspace)
-    init_git_repo_with_commit!(failing_workspace)
-    fixture_root = unique_tmp_dir("thinktank-review-eval-mixed-fixtures")
-    output_root = Path.join(unique_tmp_dir("thinktank-review-eval-mixed-output"), "runs")
+    success_workspace = Workspace.unique_tmp_dir("thinktank-review-eval-mixed-success")
+    failing_workspace = Workspace.unique_tmp_dir("thinktank-review-eval-mixed-failing")
+    Workspace.init_git_repo!(success_workspace)
+    Workspace.init_git_repo!(failing_workspace)
+    fixture_root = Workspace.unique_tmp_dir("thinktank-review-eval-mixed-fixtures")
+
+    output_root =
+      Path.join(Workspace.unique_tmp_dir("thinktank-review-eval-mixed-output"), "runs")
 
     success_contract = %RunContract{
       bench_id: "review/default",


### PR DESCRIPTION
## Summary

- Adds `test/thinktank/e2e/smoke_test.exs` — two `:e2e`-tagged tests that drive the built `./thinktank` binary against hermetic tmp workspaces with a fake `pi` on `$PATH`. Covers stdin-fed `research --json --no-synthesis` and `review eval` saved-contract replay.
- Extracts shared helpers `Thinktank.Test.FakePi` (fake-pi stub + subprocess env scrubbing) and `Thinktank.Test.Workspace` (tmp-dir + git-repo setup) under `test/support/`. Existing `agent_contract_test.exs` now consumes them.
- Wires a new `e2e-smoke` gate into the Dagger `check` task group: builds the escript and runs the smoke suite in the same `escript` cache lane.
- Default `mix test` remains fast; `:e2e` tag is excluded via `test_helper.exs` and only runs via `--include e2e` or the Dagger gate.

Drive-by bug surfaced by the new suite: `lib/thinktank/cli.ex` was calling the Elixir 1.19-deprecated `IO.read(:stdio, :all)`, and the deprecation warning leaked onto stdout, corrupting `--json` envelopes for any piped-stdin invocation. Changed to `:eof`. Committed separately.

Closes backlog 007.

## Oracle

- [x] CI runs at least one escript-backed smoke path for `research` or `review eval`
- [x] Smoke tests assert exit codes plus `contract.json`, `manifest.json`, and summary output
- [x] Coverage includes one stdin-fed command and one saved-contract replay
- [x] Suite completes in under 60 seconds locally (1.1s today)

## Test plan

- [x] `mix test` — 166 tests, 0 failures, 2 excluded
- [x] `mix escript.build && mix test --include e2e test/thinktank/e2e/smoke_test.exs` — 2 tests, 0 failures, 1.1s
- [x] `mix format --check-formatted` clean
- [x] `mix compile --warnings-as-errors` clean
- [ ] CI `e2e-smoke` Dagger gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CLI stdin handling to prevent deprecation output from corrupting piped JSON.

* **Tests**
  * Added an end-to-end smoke test suite that runs the built CLI as a subprocess, validates JSON outputs, and guards against network/API leaks.
  * Added shared hermetic test helpers and updated test config to exclude :e2e by default while allowing opt-in.

* **Chores**
  * Added a CI gate to build the escript and run the e2e smoke suite; test-only support code is compiled only in test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->