### PR TITLE
Scope USD tracking to ThinkTank runtime

### DIFF
--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -100,7 +100,7 @@ The PR comment must include screenshots or GIFs. Text tables are claims, not pro
 ## Gotchas
 
 - **Rebuild before QA.** Stale escript is the #1 false failure — always `mix escript.build` first.
-- **Full runs cost money.** Only run research/review without `--dry-run` when the PR touches agent dispatch, prompts, or synthesis.
+- **Full runs cost money — pin cheap models.** Only run research/review without `--dry-run` when the PR touches agent dispatch, prompts, or synthesis. When you do, pin the bench to cheap models: Arcee Trinity Large, Gemini 3 Flash/Flashlite, GPT-5.4 Nano, Claude Haiku, Minimax M2.7. QA verifies plumbing and artifacts, not reasoning quality — flagship tiers waste USD.
 - **Exit code 7 vs 1.** Input errors (bad args, unknown bench) exit 7. Runtime errors exit 1. Verify the distinction.
 - **JSON mode changes output shape.** `--json` wraps output in an envelope — test both human and JSON output if the PR touches formatting.
 - **Repo config is opt-in.** `.thinktank/config.yml` only loads with `--trust-repo-config`. Test both trusted and untrusted paths.

--- a/backlog.d/014-track-per-run-usd-cost.md
+++ b/backlog.d/014-track-per-run-usd-cost.md
@@ -1,0 +1,35 @@
+# Track Per-Run USD Cost
+
+Priority: medium
+Status: ready
+Estimate: S
+
+## Goal
+Every ThinkTank run records the USD cost of the model calls it made, so operators can see what a run actually cost and compare bench configurations on price.
+
+## Non-Goals
+- Billing, invoicing, or quota enforcement
+- Real-time cost streaming during a run
+- Cross-run aggregation dashboards — artifacts are the contract; rollups are a separate concern
+
+## Constraints / Invariants
+- Cost is derived from Pi's reported token usage × a per-model price table; ThinkTank does not estimate or guess
+- If any agent in a run has an unknown price, the run-level total records `usd_cost: null` with `pricing_gaps: [<model>, …]` rather than a wrong number
+- Cost accounting never gates run completion — a pricing lookup failure logs a warning, it does not fail the run
+- The thin-launcher boundary holds: ThinkTank records what Pi reports; Pi owns the token counts
+
+## Repo Anchors
+- `lib/thinktank/run_store.ex`
+- `lib/thinktank/run_contract.ex`
+- `lib/thinktank/executor/agentic.ex`
+- `lib/thinktank/engine.ex`
+
+## Oracle
+- [ ] Per-agent `usage` record includes `input_tokens`, `output_tokens`, `model`, and `usd_cost` (or `null` with a pricing gap note)
+- [ ] Run-level manifest aggregates agent costs into `usd_cost_total` plus a per-model breakdown
+- [ ] Unknown-model price resolves to `null` + warning, never a zero or fabricated number
+- [ ] Price table lives in code (not config) and is covered by tests that fail when a model in `builtin.ex` has no price
+- [ ] `thinktank runs show <id>` (or equivalent) surfaces the cost line when artifacts are inspected
+
+## Motivation
+`/flywheel` (the orchestrator) runs under a Claude Max / OpenAI Pro subscription — no per-token billing at the cycle level. ThinkTank is the opposite: every bench run hits paid APIs. Cost belongs where the money is actually spent, not in the orchestrator. This item moves USD tracking to its correct home.


### PR DESCRIPTION
## Issue

ThinkTank had no per-run USD cost tracking, while the upstream `/flywheel`
orchestrator skill (in the agent harness, not this repo) was tracking
`cap_usd` / `spent_usd` / `budget.exhausted` on every cycle. This got the
layers backwards:

- The orchestrator runs under a Claude Max / OpenAI Pro subscription —
  there is no per-token USD cost at the cycle level.
- ThinkTank is the thing that actually pays per token on every bench run,
  yet records no cost information in its run artifacts.

Additionally, `.claude/skills/qa/SKILL.md` warned that "full runs cost
money" but did not name a cheap-model menu, so QA invocations risked
burning flagship-tier tokens unnecessarily when verifying plumbing,
contracts, and artifact shapes — concerns cheap models verify just as
well.

## Cause and effect

Operators driving multi-cycle shipping loops would see a USD ceiling on
the orchestrator and reflexively want to raise it when a cycle felt
tight, while the real cost surface (ThinkTank bench runs during QA) was
invisible and uncontrolled. Meanwhile, nothing in ThinkTank's run
artifacts answered the question "what did this run cost?" — so cost
comparisons between bench configurations, or after-the-fact audits of
expensive runs, had nowhere to land.

## Root cause

Category confusion. USD-denominated cost belongs in the system that
actually makes paid API calls per token (ThinkTank). It does not belong
in an orchestrator that runs under a flat-rate subscription. The
harness-side tracking has been ripped out in a parallel harness change
(`~/.claude/skills/flywheel/`, outside this repo); this PR closes the
ThinkTank-side gap.

## Fix

1. **`.claude/skills/qa/SKILL.md`** — the "full runs cost money" gotcha
   now explicitly names the cheap-model menu (Arcee Trinity Large,
   Gemini 3 Flash / Flashlite, GPT-5.4 Nano, Claude Haiku, Minimax M2.7)
   and clarifies that QA verifies plumbing and artifacts, not reasoning
   quality, so flagship tiers waste USD. This turns an implicit gotcha
   into actionable guidance an agent can follow without having to know
   the pricing landscape.

2. **`backlog.d/014-track-per-run-usd-cost.md`** — net-new work item
   (priority: medium, estimate: S) scoping per-run USD tracking in
   `lib/thinktank/run_store.ex` and `lib/thinktank/run_contract.ex`.
   Key invariants written into the oracle:
   - Cost is derived from Pi's reported token usage × a per-model
     price table; ThinkTank does not estimate or guess.
   - Unknown-model price resolves to `usd_cost: null` with a
     `pricing_gaps` note — never a zero or fabricated number.
   - Cost accounting never gates run completion (warning, not failure).
   - Price table lives in code with tests that fail when a model in
     `builtin.ex` has no price entry.
   - Thin-launcher boundary is preserved: ThinkTank records what Pi
     reports; Pi owns the token counts.

## Tests / validation

Markdown-only changes in this PR — no Elixir code or build changes.
Dagger CI (11 gates: architecture, backlog, coveralls, dialyzer,
e2e-smoke, elixir-quality, escript, gitleaks, models, shell, yaml)
passed locally on push. Item 014 will ship with its own test suite
against the invariants above when implemented.
