### PR TITLE
fix(review): route guard reviewer to tool-capable grok-4.20

### DIFF
--- a/backlog.d/README.md
+++ b/backlog.d/README.md
@@ -44,6 +44,7 @@ See [done/](done/) for full write-ups including "What Was Built" notes.
 | [012](done/012-align-project-docs-with-thin-launcher-architecture.md) | Align Project Docs With Thin Launcher Architecture |
 | [013](done/013-add-durable-wip-scratchpads-and-partial-results-contract.md) | Add Durable WIP Scratchpads And Partial-Result Contract |
 | [014](done/014-track-per-run-usd-cost.md) | Track Per-Run USD Cost |
+| [019](done/019-fix-default-review-bench-guard-agent-incompatibility.md) | Fix Default Review Bench Guard Agent Incompatibility |
 
 ## Workflow
 

--- a/backlog.d/done/019-fix-default-review-bench-guard-agent-incompatibility.md
+++ b/backlog.d/done/019-fix-default-review-bench-guard-agent-incompatibility.md
@@ -1,0 +1,93 @@
+# Fix Default Review Bench Guard Agent Incompatibility
+
+Priority: high
+Status: done
+Estimate: S
+
+## What Was Built
+- Routed the `guard` reviewer in `review/default` to `x-ai/grok-4.20` (same reasoning tier, same pricing, tool-capable on OpenRouter) in `lib/thinktank/builtin.ex`, replacing the incompatible `x-ai/grok-4.20-multi-agent` variant.
+- Dropped the now-unused `x-ai/grok-4.20-multi-agent` entry from `lib/thinktank/pricing.ex`; every builtin model still has a price table row so `PricingTest` stays green.
+- Added a short inline capability note in `lib/thinktank/builtin.ex` above the reviewer list explaining why `*-multi-agent` variants must stay out of tool-using benches.
+- Added `test/thinktank/integration/review_bench_capability_test.exs` (`@moduletag :integration`) that probes each reviewer's OpenRouter endpoints for `tools` in `supported_parameters`; gated on `OPENROUTER_API_KEY`. Updated `test/test_helper.exs` to exclude `:integration` from the default run so `mix test` stays offline.
+
+## Goal
+
+The shipped `review/default` bench succeeds with all reviewers on every run — no silent degrade caused by a built-in agent's model being incompatible with the bench's required tool set.
+
+## Non-Goals
+
+- Reworking the review bench composition or roster.
+- Adding new reviewer agents.
+- Changing pricing or quotas.
+- Expanding the broader capability-validation work (filed as 020 below).
+
+## Constraints / Invariants
+
+- Every agent in `review/default` must be able to call the bench's declared `@agent_tools` (`bash, read, grep, find, ls`) at the configured provider.
+- Model substitutions must preserve the agent's role identity (security agent stays on a comparable security-tier reasoning model — no silent downgrade to a smaller model just to satisfy the tool requirement).
+- No change to OpenRouter routing knobs or `pi`-level invocation semantics.
+
+## Repo Anchors
+
+- `lib/thinktank/builtin.ex:97` — guard agent currently routed to `x-ai/grok-4.20-multi-agent`
+- `lib/thinktank/builtin.ex:96` — trace agent uses `x-ai/grok-4.20` (regular variant, tool-capable)
+- `lib/thinktank/pricing.ex:16` — pricing entry for `x-ai/grok-4.20-multi-agent` (drop or keep depending on whether the variant remains in the catalog)
+
+## Evidence
+
+Reproduced 2026-04-18 against thinktank 6.3.0:
+
+```
+$ thinktank review --base main --head HEAD -o /tmp/review --json
+# (run completed in degraded state: 3 of 4 reviewers ok)
+
+$ jq -r .status /tmp/review/trace/summary.json
+degraded
+
+$ cat /tmp/review/agents/guard-*.md
+Warning: Model "x-ai/grok-4.20-multi-agent" not found for provider "openrouter". Using custom model id.
+404 No endpoints found that support tool use. Try disabling "bash". To learn more about provider routing, visit: https://openrouter.ai/docs/guides/routing/provider-selection
+
+ERROR: %{category: :crash, exit_code: 1}
+```
+
+Retried 3× per default backoff; all three attempts hit the same 404. Total wasted spend: ~12s × 3 attempts on a doomed call.
+
+OpenRouter catalog confirms the model exists but does not advertise tool support:
+
+```
+$ curl -s https://openrouter.ai/api/v1/models/x-ai/grok-4.20-multi-agent/endpoints \
+  -H "Authorization: Bearer $OPENROUTER_API_KEY" \
+  | jq '.data.endpoints[].supported_parameters'
+[
+  "reasoning", "include_reasoning", "max_tokens", "temperature",
+  "top_p", "seed", "logprobs", "top_logprobs",
+  "response_format", "structured_outputs"
+]
+# Note: no "tools" entry. xAI's Multi-Agent variant orchestrates its own tool
+# fabric internally and does not accept a user-supplied tool schema through
+# OpenRouter.
+```
+
+The non-multi-agent sibling `x-ai/grok-4.20` does support tools (verified by the trace agent succeeding against the same bench).
+
+Impact on a real review run: a security-themed PR (Apollo webhook HMAC + rate limit hardening at `adminifi/vulcan` branch `feat/024a-webhook-hmac-rate-limit`, 12 files / +1201 LOC) ran with **no security reviewer**. The synthesizer correctly noted "trace and pulse checked runtime behavior" but never named the missing security perspective. For a marshal-tagged security review, silently producing a no-security-reviewer synthesis is a quality regression that the review-synth contract does not currently flag.
+
+## Oracle
+
+- [ ] `thinktank review --base main --head HEAD -o /tmp/r1` against any non-trivial diff returns `status: ok` (not `degraded`) when all configured providers are reachable.
+- [ ] `lib/thinktank/builtin.ex` guard agent uses a tool-capable model on a security-tier reasoning class (e.g. `x-ai/grok-4.20`, or another model the team selects with the same capability profile).
+- [ ] `mix test` covers the fix: a unit test asserts every reviewer in the `review_agents/0` roster is wired to a model whose OpenRouter endpoint advertises `tools` in `supported_parameters`. (Test may be marked `@tag :integration` and gated on `OPENROUTER_API_KEY`.)
+- [ ] `priv/` or wherever model capability metadata lives gets a one-line note on why the multi-agent variant is unsuitable for tool-using benches (so the next person doesn't re-add it).
+
+## Notes
+
+This bug was caught by a downstream consumer (the spellbook `/code-review` skill) running thinktank as one of three review tiers on a security PR. The other two tiers (Claude internal bench, Codex CLI) caught the security findings thinktank missed because guard never ran. Without those backstops, the shipped review would have silently lacked the security perspective on a security-themed change.
+
+For thinktank's stated trajectory — owning code review in all contexts — that silent-degrade-with-quality-gap pattern is the failure mode worth designing against. Two scoped follow-ups (file as separate items if they earn their own oracle):
+
+- **020 — Capability-aware bench validation.** Today `thinktank benches validate` is structural-only and `--dry-run` resolves bench shape without probing providers. A capability check (probe each agent's model's `supported_parameters` against the bench's `@agent_tools` requirements) would catch this class at validate-time in <2s, before any agent runs. Cheaper than catching it at run-time and clearer than the OpenRouter 404.
+
+- **021 — Domain-tagged degrade policy.** When a reviewer with a domain tag (`security`, `correctness`, `tests`, …) fails on a PR whose marshal plan invoked that tag explicitly, the run shouldn't silently degrade — it should either substitute a same-domain alternate (a backup reviewer per role), escalate the synthesizer to flag the gap loudly in the final review, or fail the run entirely if the domain is load-bearing for the diff. The current synthesis is honest about partial coverage but easy to miss; a marshal-aware degrade policy would tighten it.
+
+Both are out of scope for the immediate fix. They are listed here so the fix doesn't quietly close the bigger gap.

--- a/lib/thinktank/builtin.ex
+++ b/lib/thinktank/builtin.ex
@@ -92,9 +92,14 @@ defmodule Thinktank.Builtin do
   end
 
   defp review_agents do
+    # Reviewer models MUST advertise `tools` in their OpenRouter
+    # supported_parameters. xAI's `*-multi-agent` variants orchestrate their
+    # own tool fabric internally and do NOT accept a user-supplied tool
+    # schema over OpenRouter, so they 404 against any bench that declares
+    # @agent_tools. Keep those variants out of this roster.
     reviewers = [
       {"trace", "x-ai/grok-4.20", Review.trace(), "correctness"},
-      {"guard", "x-ai/grok-4.20-multi-agent", Review.guard(), "security"},
+      {"guard", "x-ai/grok-4.20", Review.guard(), "security"},
       {"atlas", "openai/gpt-5.4-mini", Review.atlas(), "architecture"},
       {"proof", "openai/gpt-5.4-mini", Review.proof(), "tests"},
       {"vector", "z-ai/glm-5-turbo", Review.vector(), "interfaces"},

--- a/lib/thinktank/pricing.ex
+++ b/lib/thinktank/pricing.ex
@@ -13,7 +13,6 @@ defmodule Thinktank.Pricing do
     "x-ai/grok-4.1-fast" => %{input: 0.2, output: 0.5, cache_read: 0.05},
     "google/gemini-3-flash-preview" => %{input: 0.5, output: 3.0},
     "x-ai/grok-4.20" => %{input: 1.25, output: 10.0, cache_read: 0.125},
-    "x-ai/grok-4.20-multi-agent" => %{input: 1.25, output: 10.0, cache_read: 0.125},
     "openai/gpt-5.4-mini" => %{input: 1.25, output: 10.0, cache_read: 0.125},
     "z-ai/glm-5-turbo" => %{input: 1.25, output: 10.0, cache_read: 0.125},
     "minimax/minimax-m2.7" => %{input: 1.25, output: 10.0},

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -5,5 +5,5 @@ System.put_env(
   Path.join(System.tmp_dir!(), "thinktank-test-logs-#{System.unique_integer([:positive])}")
 )
 
-ExUnit.configure(exclude: [:e2e])
+ExUnit.configure(exclude: [:e2e, :integration])
 ExUnit.start()

--- a/test/thinktank/integration/review_bench_capability_test.exs
+++ b/test/thinktank/integration/review_bench_capability_test.exs
@@ -1,13 +1,17 @@
 defmodule Thinktank.Integration.ReviewBenchCapabilityTest do
   @moduledoc """
-  Probes the live OpenRouter catalog to assert every reviewer in the built-in
-  `review/default` bench is wired to a model whose endpoints advertise
-  `tools` in `supported_parameters`. Catches the class of regression filed
-  as backlog 019: silent tool-capability drift between the bench's declared
-  @agent_tools and a reviewer's configured model.
+  Probes the live OpenRouter catalog to assert every tool-using agent in the
+  built-in `review/default` bench (reviewers, planner, synthesizer) is wired
+  to a model whose endpoints advertise `tools` in `supported_parameters`.
+  Catches the class of regression filed as backlog 019: silent tool-capability
+  drift between the bench's declared `@agent_tools`/`@summary_tools` and a
+  configured model.
 
   Tagged `:integration` because it hits `openrouter.ai`. Gated on
-  `OPENROUTER_API_KEY` — absent, the test skips.
+  `OPENROUTER_API_KEY`: absent, the test emits a loud stderr notice and
+  passes as a no-op (the `:integration` tag excludes it from the default
+  `mix test` run, so the no-op path only triggers when a caller opts in
+  without providing a key).
   """
 
   use ExUnit.Case, async: false
@@ -18,24 +22,30 @@ defmodule Thinktank.Integration.ReviewBenchCapabilityTest do
 
   @endpoints_url "https://openrouter.ai/api/v1/models"
 
-  test "every review/default reviewer uses a tool-capable OpenRouter model" do
+  test "every tool-using review/default agent uses a tool-capable OpenRouter model" do
     api_key =
       System.get_env("OPENROUTER_API_KEY") || System.get_env("THINKTANK_OPENROUTER_API_KEY")
 
     if is_nil(api_key) or api_key == "" do
-      # Oracle (backlog 019): test is gated on OPENROUTER_API_KEY.
-      IO.puts(:stderr, "skipping: OPENROUTER_API_KEY not set")
+      IO.warn(
+        "integration test skipped: OPENROUTER_API_KEY not set (nothing was probed)",
+        []
+      )
+
       :ok
     else
-      bench = Builtin.raw_config() |> get_in(["benches", "review/default"])
-      agents_map = Builtin.raw_config() |> Map.fetch!("agents")
+      config = Builtin.raw_config()
+      bench = get_in(config, ["benches", "review/default"])
+      agents_map = Map.fetch!(config, "agents")
 
-      reviewer_models =
-        bench["agents"]
-        |> Enum.map(fn name -> {name, agents_map |> Map.fetch!(name) |> Map.fetch!("model")} end)
+      agent_names =
+        ([bench["planner"] | bench["agents"]] ++ [bench["synthesizer"]])
+        |> Enum.reject(&is_nil/1)
+        |> Enum.uniq()
 
       results =
-        Enum.map(reviewer_models, fn {name, model} ->
+        Enum.map(agent_names, fn name ->
+          model = agents_map |> Map.fetch!(name) |> Map.fetch!("model")
           {name, model, tool_capable?(model, api_key)}
         end)
 

--- a/test/thinktank/integration/review_bench_capability_test.exs
+++ b/test/thinktank/integration/review_bench_capability_test.exs
@@ -1,0 +1,78 @@
+defmodule Thinktank.Integration.ReviewBenchCapabilityTest do
+  @moduledoc """
+  Probes the live OpenRouter catalog to assert every reviewer in the built-in
+  `review/default` bench is wired to a model whose endpoints advertise
+  `tools` in `supported_parameters`. Catches the class of regression filed
+  as backlog 019: silent tool-capability drift between the bench's declared
+  @agent_tools and a reviewer's configured model.
+
+  Tagged `:integration` because it hits `openrouter.ai`. Gated on
+  `OPENROUTER_API_KEY` — absent, the test skips.
+  """
+
+  use ExUnit.Case, async: false
+
+  @moduletag :integration
+
+  alias Thinktank.Builtin
+
+  @endpoints_url "https://openrouter.ai/api/v1/models"
+
+  test "every review/default reviewer uses a tool-capable OpenRouter model" do
+    api_key =
+      System.get_env("OPENROUTER_API_KEY") || System.get_env("THINKTANK_OPENROUTER_API_KEY")
+
+    if is_nil(api_key) or api_key == "" do
+      # Oracle (backlog 019): test is gated on OPENROUTER_API_KEY.
+      IO.puts(:stderr, "skipping: OPENROUTER_API_KEY not set")
+      :ok
+    else
+      bench = Builtin.raw_config() |> get_in(["benches", "review/default"])
+      agents_map = Builtin.raw_config() |> Map.fetch!("agents")
+
+      reviewer_models =
+        bench["agents"]
+        |> Enum.map(fn name -> {name, agents_map |> Map.fetch!(name) |> Map.fetch!("model")} end)
+
+      results =
+        Enum.map(reviewer_models, fn {name, model} ->
+          {name, model, tool_capable?(model, api_key)}
+        end)
+
+      failures =
+        Enum.reject(results, fn
+          {_name, _model, {:ok, true}} -> true
+          _ -> false
+        end)
+
+      assert failures == [],
+             "tool-capability check failed for:\n" <>
+               Enum.map_join(failures, "\n", fn {name, model, result} ->
+                 "  #{name} (#{model}): #{inspect(result)}"
+               end)
+    end
+  end
+
+  defp tool_capable?(model, api_key) do
+    url = "#{@endpoints_url}/#{model}/endpoints"
+    args = ["-sS", "-H", "Authorization: Bearer #{api_key}", url]
+
+    case System.cmd("curl", args, stderr_to_stdout: true) do
+      {body, 0} -> parse_endpoints(body)
+      {body, code} -> {:error, {:curl_failed, code, body}}
+    end
+  end
+
+  defp parse_endpoints(body) do
+    with {:ok, decoded} <- Jason.decode(body),
+         endpoints when is_list(endpoints) <- get_in(decoded, ["data", "endpoints"]) do
+      {:ok, Enum.any?(endpoints, &tool_endpoint?/1)}
+    else
+      other -> {:error, {:unexpected_payload, other}}
+    end
+  end
+
+  defp tool_endpoint?(endpoint) do
+    "tools" in (endpoint["supported_parameters"] || [])
+  end
+end


### PR DESCRIPTION
## Summary

- The shipped `review/default` bench silently degraded on every run: `guard` was wired to `x-ai/grok-4.20-multi-agent`, which does not accept a user-supplied tool schema on OpenRouter and 404'd against any bench declaring `@agent_tools`.
- Route `guard` to `x-ai/grok-4.20` (same reasoning tier, same pricing, tools-capable, matches the trace reviewer's known-good pairing).
- Drop the now-unused `x-ai/grok-4.20-multi-agent` pricing row. Add a capability note above the reviewer roster so the next person doesn't re-add a `*-multi-agent` variant. Add an `@tag :integration` test that probes each reviewer model's OpenRouter endpoints for `tools` in `supported_parameters`; gated on `OPENROUTER_API_KEY` and excluded from the default `mix test`.

Closes backlog 019.

## Test plan

- [x] `mix format`, `mix compile --warnings-as-errors`, `mix credo --strict`, `mix test` — all clean (200 tests, 0 failures, 3 excluded).
- [x] `mix test --include integration` runs the new capability test; passes as a no-op when `OPENROUTER_API_KEY` is unset. Live probe verified locally against the current OpenRouter catalog.
- [ ] Follow-up (outside this PR): reviewer items 020 (capability-aware `benches validate`) and 021 (domain-tagged degrade policy) remain in the backlog ticket notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an incompatibility in the default review bench by switching the guard reviewer to a tool-capable model variant.

* **Tests**
  * Added an integration test that verifies all review bench agents use models with OpenRouter tool support; integration tests are excluded from default test runs.

* **Documentation**
  * Added a backlog entry documenting the fix and related notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->