### PR TITLE
Add run inspection commands

### DIFF
--- a/.groom/review-scores.ndjson
+++ b/.groom/review-scores.ndjson
@@ -12,3 +12,4 @@
 {"date":"2026-04-16","pr":null,"correctness":9,"depth":9,"simplicity":9,"craft":9,"verdict":"ship","providers":["codex"]}
 {"date":"2026-04-18","pr":292,"correctness":8,"depth":7,"simplicity":8,"craft":8,"verdict":"ship","providers":["claude","thinktank","codex","gemini"]}
 {"date":"2026-04-20","pr":null,"correctness":8,"depth":6,"simplicity":8,"craft":8,"verdict":"conditional","providers":["codex","gemini"]}
+{"date":"2026-04-22","pr":null,"correctness":8,"depth":8,"simplicity":7,"craft":8,"verdict":"ship","providers":["codex","thinktank","gemini"]}

--- a/.groom/review-scores.ndjson
+++ b/.groom/review-scores.ndjson
@@ -13,3 +13,4 @@
 {"date":"2026-04-18","pr":292,"correctness":8,"depth":7,"simplicity":8,"craft":8,"verdict":"ship","providers":["claude","thinktank","codex","gemini"]}
 {"date":"2026-04-20","pr":null,"correctness":8,"depth":6,"simplicity":8,"craft":8,"verdict":"conditional","providers":["codex","gemini"]}
 {"date":"2026-04-22","pr":null,"correctness":8,"depth":8,"simplicity":7,"craft":8,"verdict":"ship","providers":["codex","thinktank","gemini"]}
+{"date":"2026-04-23","pr":295,"correctness":9,"depth":8,"simplicity":8,"craft":8,"verdict":"ship","providers":["subagents","thinktank","gemini"]}

--- a/README.md
+++ b/README.md
@@ -212,7 +212,11 @@ thinktank runs wait <path-or-id>
 `manifest.json` / `trace/summary.json`: `running`, `complete`, `degraded`,
 `partial`, or `failed`. `--json` wraps the same payload in a machine-safe
 `{"run": ...}` or `{"runs": [...]}` envelope so operators and scripts can
-consume it without parsing markdown.
+consume it without parsing markdown. `runs list` shows the 20 most recent
+discoverable local runs by default, sorted newest-first by `started_at`.
+`runs wait` exits `0` only when the terminal state is `complete`, returns the
+generic non-zero CLI failure status for `degraded`, `partial`, and `failed`,
+and returns the input-error status when the target cannot be resolved.
 
 If you still need the raw event stream, tail the trace file inside `output_dir`:
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ commands first:
 ```bash
 thinktank runs list
 thinktank runs show <path-or-id>
-thinktank runs wait <path-or-id>
+thinktank runs wait <path-or-id> [--timeout-ms N]
 ```
 
 `runs show` and `runs wait` surface the canonical typed run state from
@@ -216,8 +216,9 @@ consume it without parsing markdown. `runs list` shows the 20 most recent
 discoverable local runs by default, sorted newest-first by `started_at`.
 `runs wait` exits `0` only when the terminal state is `complete`, returns the
 generic non-zero CLI failure status for `degraded`, `partial`, and `failed`,
-returns the input-error status when the target cannot be resolved, and uses the
-generic failure status for malformed or unreadable run artifacts.
+returns the input-error status when the target cannot be resolved, uses the
+generic failure status for malformed or unreadable run artifacts, and waits
+indefinitely unless `--timeout-ms` is provided.
 
 If you still need the raw event stream, tail the trace file inside `output_dir`:
 

--- a/README.md
+++ b/README.md
@@ -216,7 +216,8 @@ consume it without parsing markdown. `runs list` shows the 20 most recent
 discoverable local runs by default, sorted newest-first by `started_at`.
 `runs wait` exits `0` only when the terminal state is `complete`, returns the
 generic non-zero CLI failure status for `degraded`, `partial`, and `failed`,
-and returns the input-error status when the target cannot be resolved.
+returns the input-error status when the target cannot be resolved, and uses the
+generic failure status for malformed or unreadable run artifacts.
 
 If you still need the raw event stream, tail the trace file inside `output_dir`:
 

--- a/README.md
+++ b/README.md
@@ -199,8 +199,22 @@ If a run times out, is interrupted, or loses synthesis after useful work has
 already been captured, ThinkTank finalizes it as `partial` and writes a
 best-effort summary from the scratchpads and available artifacts.
 
-If you need to inspect the same run from another shell, tail the trace file
-inside `output_dir`:
+If you need to inspect the same run from another shell, use the run inspection
+commands first:
+
+```bash
+thinktank runs list
+thinktank runs show <path-or-id>
+thinktank runs wait <path-or-id>
+```
+
+`runs show` and `runs wait` surface the canonical typed run state from
+`manifest.json` / `trace/summary.json`: `running`, `complete`, `degraded`,
+`partial`, or `failed`. `--json` wraps the same payload in a machine-safe
+`{"run": ...}` or `{"runs": [...]}` envelope so operators and scripts can
+consume it without parsing markdown.
+
+If you still need the raw event stream, tail the trace file inside `output_dir`:
 
 ```bash
 tail -f /path/to/run/trace/events.jsonl

--- a/backlog.d/README.md
+++ b/backlog.d/README.md
@@ -20,7 +20,6 @@ Status conventions:
 
 | # | Title | Priority | Estimate |
 |---|-------|----------|----------|
-| [022](022-add-run-inspection-and-explicit-run-state-commands.md) | Add Run Inspection And Explicit Run State Commands | high | M |
 | [023](023-add-structured-research-findings-contract.md) | Add Structured Research Findings Contract | high | M |
 | [024](024-add-first-class-focused-review-benches.md) | Add First-Class Focused Review Benches | medium | M |
 | [018](018-centralize-gate-policy-sources-and-remove-overlap.md) | Centralize Gate Policy Sources And Remove Overlap | medium | M |
@@ -50,6 +49,7 @@ See [done/](done/) for full write-ups including "What Was Built" notes.
 | [016](done/016-add-run-session-and-single-lifecycle-owner.md) | Add Run Session And Single Lifecycle Owner |
 | [017](done/017-reduce-review-control-plane-to-structured-contracts.md) | Reduce Review Control Plane To Structured Contracts |
 | [019](done/019-fix-default-review-bench-guard-agent-incompatibility.md) | Fix Default Review Bench Guard Agent Incompatibility |
+| [022](done/022-add-run-inspection-and-explicit-run-state-commands.md) | Add Run Inspection And Explicit Run State Commands |
 
 ## Workflow
 

--- a/backlog.d/done/022-add-run-inspection-and-explicit-run-state-commands.md
+++ b/backlog.d/done/022-add-run-inspection-and-explicit-run-state-commands.md
@@ -1,7 +1,7 @@
 # Add Run Inspection And Explicit Run State Commands
 
 Priority: high
-Status: ready
+Status: done
 Estimate: M
 
 ## Goal
@@ -30,13 +30,20 @@ Operators can inspect, tail, and wait on research and review runs through first-
 - `README.md`
 
 ## Oracle
-- [ ] `thinktank runs list` shows recent local runs with bench, status, start time, and output directory
-- [ ] `thinktank runs show <path-or-id>` reports a typed state (`running`, `complete`, `degraded`, `partial`, `failed`) without requiring manual trace-file inspection
-- [ ] `thinktank runs wait <path-or-id>` blocks until terminal state and exits deterministically based on the final run status
-- [ ] JSON output for the new commands is additive and documented in `README.md`
-- [ ] Automated coverage proves the commands against complete, degraded, partial, failed, and still-running runs
+- [x] `thinktank runs list` shows recent local runs with bench, status, start time, and output directory
+- [x] `thinktank runs show <path-or-id>` reports a typed state (`running`, `complete`, `degraded`, `partial`, `failed`) without requiring manual trace-file inspection
+- [x] `thinktank runs wait <path-or-id>` blocks until terminal state and exits deterministically based on the final run status
+- [x] JSON output for the new commands is additive and documented in `README.md`
+- [x] Automated coverage proves the commands against complete, degraded, partial, failed, and still-running runs
 
 ## Notes
 Today the README tells operators to tail `trace/events.jsonl` directly to inspect a live run. That is a useful escape hatch, but not a good product default. Research and review both feel less trustworthy when completion and liveness are implicit.
 
 This item is the UX layer on top of the contract work in `015` and `016`: once run-state is explicit and lifecycle ownership is centralized, ThinkTank should surface that state directly instead of forcing users to reason from artifacts.
+
+## What Was Built
+- Added `thinktank runs list`, `thinktank runs show <path-or-id>`, and `thinktank runs wait <path-or-id>` on top of the existing manifest/trace contract instead of inventing a second state system.
+- Added `Thinktank.RunInspector` to discover recent local runs, resolve a run by path or id, read typed state from durable artifacts, and wait until terminal state.
+- Extended the CLI help text and JSON/text renderers so run inspection stays machine-safe under `--json` and readable in plain text.
+- Documented the new inspection flow in `README.md`, keeping raw trace tailing as an escape hatch rather than the primary UX.
+- Added coverage for complete, degraded, partial, failed, and still-running runs, plus CLI parsing and exit-code behavior for the new commands.

--- a/lib/thinktank/cli.ex
+++ b/lib/thinktank/cli.ex
@@ -107,9 +107,16 @@ defmodule Thinktank.CLI do
   end
 
   def execute({:ok, %{action: :runs_list} = command}) do
-    {:ok, runs} = RunInspector.list()
-    emit_runs_list(runs, command)
-    @exit_codes.success
+    case RunInspector.list() do
+      {:ok, runs} ->
+        emit_runs_list(runs, command)
+        @exit_codes.success
+
+      {:error, reason} ->
+        error = normalize_error(reason)
+        emit_error(command, error, nil)
+        runs_error_exit_code(error)
+    end
   end
 
   def execute({:ok, %{action: :runs_show, target: target} = command}) do

--- a/lib/thinktank/cli.ex
+++ b/lib/thinktank/cli.ex
@@ -107,15 +107,13 @@ defmodule Thinktank.CLI do
   end
 
   def execute({:ok, %{action: :runs_list} = command}) do
-    case RunInspector.list() do
+    case command |> runs_list_opts() |> RunInspector.list() do
       {:ok, runs} ->
         emit_runs_list(runs, command)
         @exit_codes.success
 
       {:error, reason} ->
-        error = normalize_error(reason)
-        emit_error(command, error, nil)
-        runs_error_exit_code(error)
+        emit_runs_error(command, reason)
     end
   end
 
@@ -126,14 +124,12 @@ defmodule Thinktank.CLI do
         @exit_codes.success
 
       {:error, reason} ->
-        error = normalize_error(reason)
-        emit_error(command, error, nil)
-        runs_error_exit_code(error)
+        emit_runs_error(command, reason)
     end
   end
 
   def execute({:ok, %{action: :runs_wait, target: target} = command}) do
-    case RunInspector.wait(target) do
+    case RunInspector.wait(target, runs_wait_opts(command)) do
       {:ok, run} ->
         emit_run(run, command)
 
@@ -143,9 +139,7 @@ defmodule Thinktank.CLI do
         end
 
       {:error, reason} ->
-        error = normalize_error(reason)
-        emit_error(command, error, nil)
-        runs_error_exit_code(error)
+        emit_runs_error(command, reason)
     end
   end
 
@@ -297,12 +291,36 @@ defmodule Thinktank.CLI do
     |> IO.puts()
   end
 
-  defp runs_error_exit_code(%Error{code: code})
-       when code in [:run_target_not_found, :run_target_ambiguous, :invalid_run_target] do
-    @exit_codes.input_error
+  defp runs_wait_opts(command) do
+    case Map.get(command, :timeout_ms) do
+      nil -> []
+      timeout_ms -> [timeout_ms: timeout_ms]
+    end
   end
 
-  defp runs_error_exit_code(_error), do: @exit_codes.generic_error
+  defp runs_list_opts(command) do
+    command
+    |> Map.take([:limit])
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+  end
+
+  defp emit_runs_error(command, reason) do
+    error = normalize_error(reason)
+    emit_error(command, error, runs_error_output_dir(error))
+    runs_error_exit_code(error)
+  end
+
+  defp runs_error_output_dir(%Error{details: %{output_dir: output_dir}})
+       when is_binary(output_dir),
+       do: output_dir
+
+  defp runs_error_output_dir(_error), do: nil
+
+  defp runs_error_exit_code(%Error{} = error) do
+    if RunInspector.input_error?(error),
+      do: @exit_codes.input_error,
+      else: @exit_codes.generic_error
+  end
 
   defp emit_runs_list(runs, %{json: true}) do
     runs

--- a/lib/thinktank/cli.ex
+++ b/lib/thinktank/cli.ex
@@ -10,6 +10,7 @@ defmodule Thinktank.CLI do
   alias Thinktank.Error
   alias Thinktank.ProgressReporter
   alias Thinktank.Review.Eval
+  alias Thinktank.RunInspector
 
   @exit_codes %{
     success: 0,
@@ -98,6 +99,40 @@ defmodule Thinktank.CLI do
         |> emit_benches_validate(command)
 
         @exit_codes.success
+
+      {:error, reason} ->
+        emit_error(command, normalize_error(reason), nil)
+        @exit_codes.input_error
+    end
+  end
+
+  def execute({:ok, %{action: :runs_list} = command}) do
+    {:ok, runs} = RunInspector.list()
+    emit_runs_list(runs, command)
+    @exit_codes.success
+  end
+
+  def execute({:ok, %{action: :runs_show, target: target} = command}) do
+    case RunInspector.show(target) do
+      {:ok, run} ->
+        emit_run(run, command)
+        @exit_codes.success
+
+      {:error, reason} ->
+        emit_error(command, normalize_error(reason), nil)
+        @exit_codes.input_error
+    end
+  end
+
+  def execute({:ok, %{action: :runs_wait, target: target} = command}) do
+    case RunInspector.wait(target) do
+      {:ok, run} ->
+        emit_run(run, command)
+
+        case run.status do
+          "complete" -> @exit_codes.success
+          _ -> @exit_codes.generic_error
+        end
 
       {:error, reason} ->
         emit_error(command, normalize_error(reason), nil)
@@ -250,6 +285,30 @@ defmodule Thinktank.CLI do
   defp emit_benches_show(payload, _command) do
     payload
     |> Render.benches_show_text()
+    |> IO.puts()
+  end
+
+  defp emit_runs_list(runs, %{json: true}) do
+    runs
+    |> Render.runs_list_json()
+    |> IO.puts()
+  end
+
+  defp emit_runs_list(runs, _command) do
+    runs
+    |> Render.runs_list_text()
+    |> IO.puts()
+  end
+
+  defp emit_run(run, %{json: true}) do
+    run
+    |> Render.run_json()
+    |> IO.puts()
+  end
+
+  defp emit_run(run, _command) do
+    run
+    |> Render.run_text()
     |> IO.puts()
   end
 

--- a/lib/thinktank/cli.ex
+++ b/lib/thinktank/cli.ex
@@ -119,8 +119,9 @@ defmodule Thinktank.CLI do
         @exit_codes.success
 
       {:error, reason} ->
-        emit_error(command, normalize_error(reason), nil)
-        @exit_codes.input_error
+        error = normalize_error(reason)
+        emit_error(command, error, nil)
+        runs_error_exit_code(error)
     end
   end
 
@@ -135,8 +136,9 @@ defmodule Thinktank.CLI do
         end
 
       {:error, reason} ->
-        emit_error(command, normalize_error(reason), nil)
-        @exit_codes.input_error
+        error = normalize_error(reason)
+        emit_error(command, error, nil)
+        runs_error_exit_code(error)
     end
   end
 
@@ -287,6 +289,13 @@ defmodule Thinktank.CLI do
     |> Render.benches_show_text()
     |> IO.puts()
   end
+
+  defp runs_error_exit_code(%Error{code: code})
+       when code in [:run_target_not_found, :run_target_ambiguous, :invalid_run_target] do
+    @exit_codes.input_error
+  end
+
+  defp runs_error_exit_code(_error), do: @exit_codes.generic_error
 
   defp emit_runs_list(runs, %{json: true}) do
     runs

--- a/lib/thinktank/cli/parser.ex
+++ b/lib/thinktank/cli/parser.ex
@@ -20,7 +20,8 @@ defmodule Thinktank.CLI.Parser do
       base: :string,
       head: :string,
       repo: :string,
-      pr: :integer
+      pr: :integer,
+      timeout_ms: :integer
     ],
     aliases: [
       h: :help,
@@ -161,13 +162,16 @@ defmodule Thinktank.CLI.Parser do
   end
 
   defp build_command(["runs", "wait", target], parsed) do
-    {:ok,
-     %{
-       action: :runs_wait,
-       target: target,
-       cwd: File.cwd!(),
-       json: parsed[:json] || false
-     }}
+    with {:ok, timeout_ms} <- parse_timeout_ms(parsed[:timeout_ms]) do
+      {:ok,
+       %{
+         action: :runs_wait,
+         target: target,
+         cwd: File.cwd!(),
+         json: parsed[:json] || false,
+         timeout_ms: timeout_ms
+       }}
+    end
   end
 
   defp build_command(["runs" | _rest], _parsed) do
@@ -251,6 +255,13 @@ defmodule Thinktank.CLI.Parser do
     |> maybe_put_value(:repo, parsed[:repo])
     |> maybe_put_value(:pr, parsed[:pr])
   end
+
+  defp parse_timeout_ms(nil), do: {:ok, nil}
+
+  defp parse_timeout_ms(timeout_ms) when is_integer(timeout_ms) and timeout_ms >= 0,
+    do: {:ok, timeout_ms}
+
+  defp parse_timeout_ms(_timeout_ms), do: {:error, "--timeout-ms must be a non-negative integer"}
 
   defp validate_review_pr_flags(%BenchSpec{id: bench_id} = bench, parsed) do
     parsed = if is_map(parsed), do: parsed, else: Map.new(parsed)

--- a/lib/thinktank/cli/parser.ex
+++ b/lib/thinktank/cli/parser.ex
@@ -141,6 +141,39 @@ defmodule Thinktank.CLI.Parser do
      }}
   end
 
+  defp build_command(["runs", "list"], parsed) do
+    {:ok,
+     %{
+       action: :runs_list,
+       cwd: File.cwd!(),
+       json: parsed[:json] || false
+     }}
+  end
+
+  defp build_command(["runs", "show", target], parsed) do
+    {:ok,
+     %{
+       action: :runs_show,
+       target: target,
+       cwd: File.cwd!(),
+       json: parsed[:json] || false
+     }}
+  end
+
+  defp build_command(["runs", "wait", target], parsed) do
+    {:ok,
+     %{
+       action: :runs_wait,
+       target: target,
+       cwd: File.cwd!(),
+       json: parsed[:json] || false
+     }}
+  end
+
+  defp build_command(["runs" | _rest], _parsed) do
+    {:error, "runs expects list, show <path-or-id>, or wait <path-or-id>"}
+  end
+
   defp build_command([group, "show", bench_id], parsed) when group in ["benches", "workflows"] do
     {:ok,
      %{

--- a/lib/thinktank/cli/render.ex
+++ b/lib/thinktank/cli/render.ex
@@ -13,7 +13,7 @@ defmodule Thinktank.CLI.Render do
       thinktank research "..." [options]
       thinktank review [options]
       thinktank review eval <contract-or-dir> [--bench <bench>]
-      thinktank runs list|show <path-or-id>|wait <path-or-id>
+      thinktank runs list|show <path-or-id>|wait <path-or-id> [--timeout-ms N]
       thinktank benches list|show|validate
 
     Task text can come from --input, positional text, or piped stdin.
@@ -32,6 +32,7 @@ defmodule Thinktank.CLI.Render do
       --head REF            Review head ref
       --repo REPO           Review repo owner/name
       --pr N                Review pull request number
+      --timeout-ms N        Bound runs wait polling in milliseconds
 
     Examples:
       thinktank research "analyze this codebase" --paths ./lib

--- a/lib/thinktank/cli/render.ex
+++ b/lib/thinktank/cli/render.ex
@@ -13,6 +13,7 @@ defmodule Thinktank.CLI.Render do
       thinktank research "..." [options]
       thinktank review [options]
       thinktank review eval <contract-or-dir> [--bench <bench>]
+      thinktank runs list|show <path-or-id>|wait <path-or-id>
       thinktank benches list|show|validate
 
     Task text can come from --input, positional text, or piped stdin.
@@ -118,6 +119,49 @@ defmodule Thinktank.CLI.Render do
     Agents:
     #{render_bench_show_agent_lines(payload.agents)}
     """
+  end
+
+  @spec runs_list_json([map()]) :: String.t()
+  def runs_list_json(runs), do: Jason.encode!(%{runs: runs})
+
+  @spec runs_list_text([map()]) :: String.t()
+  def runs_list_text([]), do: "No runs found"
+
+  def runs_list_text(runs) do
+    rows =
+      Enum.map_join(runs, "\n", fn run ->
+        [
+          run.id,
+          run.status,
+          run.bench || "unknown",
+          run.started_at || "unknown",
+          run.output_dir
+        ]
+        |> Enum.join("\t")
+      end)
+
+    "ID\tSTATUS\tBENCH\tSTARTED\tOUTPUT\n" <> rows
+  end
+
+  @spec run_json(map()) :: String.t()
+  def run_json(run), do: Jason.encode!(%{run: run})
+
+  @spec run_text(map()) :: String.t()
+  def run_text(run) do
+    """
+    Run: #{run.id}
+    Bench: #{run.bench || "unknown"}
+    Kind: #{run.kind || "unknown"}
+    Status: #{run.status}
+    Started: #{run.started_at || "unknown"}
+    Completed: #{run.completed_at || "pending"}
+    Output: #{run.output_dir}
+    Workspace: #{run.workspace_root || "unknown"}
+    Manifest: #{run.manifest_file || "none"}
+    Trace Summary: #{run.trace_summary_file || "none"}
+    Trace Events: #{run.trace_events_file || "none"}
+    """
+    |> String.trim()
   end
 
   @spec resolve_agents_payload(map(), map(), boolean()) ::

--- a/lib/thinktank/run_inspector.ex
+++ b/lib/thinktank/run_inspector.ex
@@ -79,18 +79,15 @@ defmodule Thinktank.RunInspector do
   end
 
   defp resolve_target(target, opts) do
-    case output_dir_from_path(target) do
+    case resolve_target_path(target) do
       {:ok, output_dir} ->
         {:ok, output_dir}
 
-      :path_not_found ->
-        {:error, "run not found: #{target}"}
-
-      :not_a_run ->
-        {:error, "not a ThinkTank run directory: #{target}"}
-
-      :no_path_match ->
+      :not_a_path_target ->
         resolve_target_id(target, opts)
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
@@ -112,30 +109,37 @@ defmodule Thinktank.RunInspector do
     end
   end
 
-  defp output_dir_from_path(target) do
-    expanded = Path.expand(target)
-
-    cond do
-      File.dir?(expanded) ->
-        if run_dir?(expanded), do: {:ok, expanded}, else: :not_a_run
-
-      File.exists?(expanded) ->
-        expanded
-        |> infer_run_dir_from_file()
-        |> case do
-          nil -> :not_a_run
-          output_dir -> {:ok, output_dir}
-        end
-
-      path_like_target?(target) ->
-        :path_not_found
-
-      true ->
-        :no_path_match
+  defp resolve_target_path(target) do
+    if path_target?(target) do
+      target
+      |> Path.expand()
+      |> resolve_existing_path(target)
+    else
+      :not_a_path_target
     end
   end
 
-  defp infer_run_dir_from_file(path) do
+  defp resolve_existing_path(expanded, original_target) do
+    candidate =
+      cond do
+        File.dir?(expanded) -> expanded
+        File.exists?(expanded) -> run_dir_from_artifact_path(expanded)
+        true -> :missing
+      end
+
+    cond do
+      candidate == :missing ->
+        {:error, "run not found: #{original_target}"}
+
+      run_dir?(candidate) ->
+        {:ok, candidate}
+
+      true ->
+        {:error, "not a ThinkTank run directory: #{original_target}"}
+    end
+  end
+
+  defp run_dir_from_artifact_path(path) do
     cond do
       String.ends_with?(path, "/" <> ArtifactLayout.manifest_file()) ->
         Path.dirname(path)
@@ -154,7 +158,7 @@ defmodule Thinktank.RunInspector do
     end
   end
 
-  defp path_like_target?(target) do
+  defp path_target?(target) do
     String.contains?(target, ["/", "\\"]) || String.starts_with?(target, ".") ||
       String.starts_with?(target, "~")
   end

--- a/lib/thinktank/run_inspector.ex
+++ b/lib/thinktank/run_inspector.ex
@@ -1,0 +1,339 @@
+defmodule Thinktank.RunInspector do
+  @moduledoc """
+  Reads durable run artifacts and exposes inspection helpers for CLI commands.
+  """
+
+  alias Thinktank.{ArtifactLayout, RunTracker, TraceLog}
+
+  @known_statuses ~w(running complete degraded partial failed)
+  @terminal_statuses ~w(complete degraded partial failed)
+  @default_poll_ms 100
+  @default_limit 20
+
+  @type run_info :: %{
+          id: String.t(),
+          output_dir: String.t(),
+          bench: String.t() | nil,
+          kind: String.t() | nil,
+          status: String.t(),
+          started_at: String.t() | nil,
+          completed_at: String.t() | nil,
+          workspace_root: String.t() | nil,
+          manifest_file: String.t() | nil,
+          trace_summary_file: String.t() | nil,
+          trace_events_file: String.t() | nil
+        }
+
+  @spec list(keyword()) :: {:ok, [run_info()]}
+  def list(opts \\ []) do
+    limit = Keyword.get(opts, :limit, @default_limit)
+
+    runs =
+      opts
+      |> discover_output_dirs()
+      |> Enum.map(&load_run(&1, :lenient))
+      |> Enum.reject(&is_nil/1)
+      |> Enum.map(fn {:ok, run} -> run end)
+      |> Enum.sort_by(&{sort_timestamp(&1), &1.id, &1.output_dir}, :desc)
+      |> maybe_limit(limit)
+
+    {:ok, runs}
+  end
+
+  @spec show(String.t(), keyword()) :: {:ok, run_info()} | {:error, String.t()}
+  def show(target, opts \\ []) when is_binary(target) do
+    with {:ok, output_dir} <- resolve_target(target, opts) do
+      load_run(output_dir)
+    end
+  end
+
+  @spec wait(String.t(), keyword()) :: {:ok, run_info()} | {:error, String.t()}
+  def wait(target, opts \\ []) when is_binary(target) do
+    poll_ms = Keyword.get(opts, :poll_ms, @default_poll_ms)
+    timeout_ms = Keyword.get(opts, :timeout_ms, :infinity)
+
+    with {:ok, output_dir} <- resolve_target(target, opts) do
+      wait_for_terminal(output_dir, poll_ms, deadline_after(timeout_ms))
+    end
+  end
+
+  @spec terminal_status?(String.t()) :: boolean()
+  def terminal_status?(status) when is_binary(status), do: status in @terminal_statuses
+
+  defp wait_for_terminal(output_dir, poll_ms, deadline) do
+    case load_run(output_dir) do
+      {:ok, %{status: status} = run} when status in @terminal_statuses ->
+        {:ok, run}
+
+      {:ok, _run} ->
+        if timed_out?(deadline) do
+          {:error, "timed out waiting for run to finish: #{output_dir}"}
+        else
+          Process.sleep(poll_ms)
+          wait_for_terminal(output_dir, poll_ms, deadline)
+        end
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp resolve_target(target, opts) do
+    case output_dir_from_path(target) do
+      {:ok, output_dir} ->
+        {:ok, output_dir}
+
+      :path_not_found ->
+        {:error, "run not found: #{target}"}
+
+      :not_a_run ->
+        {:error, "not a ThinkTank run directory: #{target}"}
+
+      :no_path_match ->
+        resolve_target_id(target, opts)
+    end
+  end
+
+  defp resolve_target_id(target, opts) do
+    matches =
+      opts
+      |> discover_output_dirs()
+      |> Enum.filter(&(Path.basename(&1) == target))
+
+    case matches do
+      [output_dir] ->
+        {:ok, output_dir}
+
+      [] ->
+        {:error, "run not found: #{target}"}
+
+      _ ->
+        {:error, "multiple runs match #{target}; use an explicit path"}
+    end
+  end
+
+  defp output_dir_from_path(target) do
+    expanded = Path.expand(target)
+
+    cond do
+      File.dir?(expanded) ->
+        if run_dir?(expanded), do: {:ok, expanded}, else: :not_a_run
+
+      File.exists?(expanded) ->
+        expanded
+        |> infer_run_dir_from_file()
+        |> case do
+          nil -> :not_a_run
+          output_dir -> {:ok, output_dir}
+        end
+
+      path_like_target?(target) ->
+        :path_not_found
+
+      true ->
+        :no_path_match
+    end
+  end
+
+  defp infer_run_dir_from_file(path) do
+    cond do
+      String.ends_with?(path, "/" <> ArtifactLayout.manifest_file()) ->
+        Path.dirname(path)
+
+      String.ends_with?(path, "/" <> ArtifactLayout.contract_file()) ->
+        Path.dirname(path)
+
+      String.ends_with?(path, "/" <> TraceLog.summary_file()) ->
+        path |> Path.dirname() |> Path.dirname()
+
+      String.ends_with?(path, "/" <> TraceLog.events_file()) ->
+        path |> Path.dirname() |> Path.dirname()
+
+      true ->
+        nil
+    end
+  end
+
+  defp path_like_target?(target) do
+    String.contains?(target, ["/", "\\"]) || String.starts_with?(target, ".") ||
+      String.starts_with?(target, "~")
+  end
+
+  defp discover_output_dirs(opts) do
+    [
+      tracked_output_dirs(),
+      tmp_output_dirs(Keyword.get(opts, :tmp_dir, System.tmp_dir!())),
+      log_output_dirs(Keyword.get(opts, :log_dir, TraceLog.global_log_dir()))
+    ]
+    |> List.flatten()
+    |> Enum.map(&Path.expand/1)
+    |> Enum.uniq()
+  end
+
+  defp tracked_output_dirs do
+    Enum.map(RunTracker.active_runs(), fn {output_dir, _attrs} -> output_dir end)
+  end
+
+  defp tmp_output_dirs(tmp_dir) do
+    [
+      Path.join(tmp_dir, "thinktank-*"),
+      Path.join(tmp_dir, "thinktank-*/*")
+    ]
+    |> Enum.flat_map(&Path.wildcard/1)
+    |> Enum.filter(&run_dir?/1)
+  end
+
+  defp log_output_dirs(nil), do: []
+
+  defp log_output_dirs(log_dir) do
+    if File.dir?(log_dir) do
+      log_dir
+      |> Path.join("*.jsonl")
+      |> Path.wildcard()
+      |> Enum.sort(:desc)
+      |> Enum.flat_map(&read_log_output_dirs/1)
+    else
+      []
+    end
+  end
+
+  defp read_log_output_dirs(path) do
+    path
+    |> File.stream!(:line, [])
+    |> Enum.reduce([], fn line, acc ->
+      case Jason.decode(line) do
+        {:ok, %{"output_dir" => output_dir}} when is_binary(output_dir) ->
+          [output_dir | acc]
+
+        _ ->
+          acc
+      end
+    end)
+  rescue
+    _ -> []
+  end
+
+  defp run_dir?(output_dir) do
+    File.exists?(Path.join(output_dir, ArtifactLayout.manifest_file())) ||
+      File.exists?(Path.join(output_dir, TraceLog.summary_file()))
+  end
+
+  defp load_run(output_dir, mode \\ :strict) do
+    case do_load_run(Path.expand(output_dir)) do
+      {:ok, run} -> {:ok, run}
+      {:error, _reason} when mode == :lenient -> nil
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp do_load_run(output_dir) do
+    paths = run_paths(output_dir)
+
+    with {:ok, manifest} <- read_json_optional(paths.manifest),
+         {:ok, summary} <- read_json_optional(paths.summary),
+         {:ok, contract} <- read_json_optional(paths.contract),
+         :ok <- ensure_run_artifacts(output_dir, manifest, summary, contract),
+         {:ok, status} <- derive_status(manifest, summary) do
+      {:ok, build_run_info(output_dir, paths, manifest, summary, contract, status)}
+    end
+  end
+
+  defp ensure_run_artifacts(output_dir, nil, nil, nil),
+    do: {:error, "run artifacts not found: #{output_dir}"}
+
+  defp ensure_run_artifacts(_output_dir, _manifest, _summary, _contract), do: :ok
+
+  defp derive_status(manifest, summary) do
+    case manifest_value(manifest, "status") || manifest_value(summary, "status") do
+      status when status in @known_statuses -> {:ok, status}
+      nil -> {:error, "run status is missing"}
+      status -> {:error, "unknown run status: #{inspect(status)}"}
+    end
+  end
+
+  defp read_json_optional(path) do
+    if File.exists?(path), do: read_json_file(path), else: {:ok, nil}
+  end
+
+  defp read_json_file(path) do
+    with {:ok, body} <- File.read(path),
+         {:ok, decoded} <- decode_json_object(body, path) do
+      {:ok, decoded}
+    else
+      {:error, reason} when is_binary(reason) ->
+        {:error, reason}
+
+      {:error, reason} ->
+        {:error, "failed to read #{path}: #{:file.format_error(reason)}"}
+    end
+  end
+
+  defp decode_json_object(body, path) do
+    case Jason.decode(body) do
+      {:ok, decoded} when is_map(decoded) -> {:ok, decoded}
+      {:ok, _decoded} -> {:error, "expected JSON object at #{path}"}
+      {:error, reason} -> {:error, "failed to decode #{path}: #{Exception.message(reason)}"}
+    end
+  end
+
+  defp build_run_info(output_dir, paths, manifest, summary, contract, status) do
+    bench =
+      manifest_value(manifest, "bench") ||
+        manifest_value(summary, "bench") ||
+        manifest_value(contract, "bench_id")
+
+    %{
+      id: Path.basename(output_dir),
+      output_dir: output_dir,
+      bench: bench,
+      kind: manifest_value(manifest, "kind") || infer_kind(bench),
+      status: status,
+      started_at: manifest_value(manifest, "started_at") || manifest_value(summary, "started_at"),
+      completed_at:
+        manifest_value(manifest, "completed_at") || manifest_value(summary, "completed_at"),
+      workspace_root:
+        manifest_value(manifest, "workspace_root") || manifest_value(contract, "workspace_root"),
+      manifest_file: existing_path(paths.manifest),
+      trace_summary_file: existing_path(paths.summary),
+      trace_events_file: existing_path(paths.events)
+    }
+  end
+
+  defp run_paths(output_dir) do
+    %{
+      manifest: Path.join(output_dir, ArtifactLayout.manifest_file()),
+      summary: Path.join(output_dir, TraceLog.summary_file()),
+      events: Path.join(output_dir, TraceLog.events_file()),
+      contract: Path.join(output_dir, ArtifactLayout.contract_file())
+    }
+  end
+
+  defp manifest_value(nil, _key), do: nil
+  defp manifest_value(map, key), do: Map.get(map, key)
+
+  defp existing_path(path), do: if(File.exists?(path), do: path, else: nil)
+
+  defp infer_kind(nil), do: nil
+
+  defp infer_kind(bench_id) when is_binary(bench_id) do
+    cond do
+      String.starts_with?(bench_id, "review/") -> "review"
+      String.starts_with?(bench_id, "research/") -> "research"
+      true -> nil
+    end
+  end
+
+  defp sort_timestamp(run), do: run.started_at || run.completed_at || ""
+
+  defp maybe_limit(runs, nil), do: runs
+  defp maybe_limit(runs, limit) when is_integer(limit) and limit >= 0, do: Enum.take(runs, limit)
+
+  defp deadline_after(:infinity), do: :infinity
+
+  defp deadline_after(timeout_ms) when is_integer(timeout_ms) and timeout_ms >= 0 do
+    System.monotonic_time(:millisecond) + timeout_ms
+  end
+
+  defp timed_out?(:infinity), do: false
+  defp timed_out?(deadline), do: System.monotonic_time(:millisecond) >= deadline
+end

--- a/lib/thinktank/run_inspector.ex
+++ b/lib/thinktank/run_inspector.ex
@@ -3,7 +3,7 @@ defmodule Thinktank.RunInspector do
   Reads durable run artifacts and exposes inspection helpers for CLI commands.
   """
 
-  alias Thinktank.{ArtifactLayout, RunTracker, TraceLog}
+  alias Thinktank.{ArtifactLayout, Error, RunTracker, TraceLog}
 
   @known_statuses ~w(running complete degraded partial failed)
   @terminal_statuses ~w(complete degraded partial failed)
@@ -24,42 +24,21 @@ defmodule Thinktank.RunInspector do
           trace_events_file: String.t() | nil
         }
 
-  @type error_reason :: %{
-          required(:category) => atom(),
-          required(:message) => String.t(),
-          optional(atom()) => term()
-        }
-
-  @spec list(keyword()) :: {:ok, [run_info()]} | {:error, error_reason()}
+  @spec list(keyword()) :: {:ok, [run_info()]} | {:error, Error.t()}
   def list(opts \\ []) do
-    limit = Keyword.get(opts, :limit, @default_limit)
-
-    runs =
-      opts
-      |> discover_output_dirs()
-      |> Enum.flat_map(fn output_dir ->
-        case load_run(output_dir, :lenient) do
-          {:ok, run} -> [run]
-          nil -> []
-        end
-      end)
-      |> Enum.sort_by(&{sort_timestamp(&1), &1.id, &1.output_dir}, :desc)
-      |> maybe_limit(limit)
-
-    {:ok, runs}
-  rescue
-    exception ->
-      error(:run_list_failed, "failed to discover runs", reason: Exception.message(exception))
+    with {:ok, limit} <- list_limit(opts) do
+      {:ok, load_listed_runs(opts, limit)}
+    end
   end
 
-  @spec show(String.t(), keyword()) :: {:ok, run_info()} | {:error, error_reason()}
+  @spec show(String.t(), keyword()) :: {:ok, run_info()} | {:error, Error.t()}
   def show(target, opts \\ []) when is_binary(target) do
     with {:ok, output_dir} <- resolve_target(target, opts) do
       load_run(output_dir)
     end
   end
 
-  @spec wait(String.t(), keyword()) :: {:ok, run_info()} | {:error, error_reason()}
+  @spec wait(String.t(), keyword()) :: {:ok, run_info()} | {:error, Error.t()}
   def wait(target, opts \\ []) when is_binary(target) do
     poll_ms = Keyword.get(opts, :poll_ms, @default_poll_ms)
     timeout_ms = Keyword.get(opts, :timeout_ms, :infinity)
@@ -71,6 +50,18 @@ defmodule Thinktank.RunInspector do
 
   @spec terminal_status?(String.t()) :: boolean()
   def terminal_status?(status) when is_binary(status), do: status in @terminal_statuses
+
+  @spec input_error?(Error.t()) :: boolean()
+  def input_error?(%Error{code: code})
+      when code in [
+             :run_target_not_found,
+             :run_target_ambiguous,
+             :invalid_run_target,
+             :invalid_run_list_limit
+           ],
+      do: true
+
+  def input_error?(_error), do: false
 
   defp wait_for_terminal(output_dir, poll_ms, deadline) do
     case load_run(output_dir) do
@@ -130,36 +121,20 @@ defmodule Thinktank.RunInspector do
   defp resolve_target_path(target) do
     expanded = Path.expand(target)
 
-    if path_target?(target) || File.exists?(expanded) do
-      resolve_existing_path(expanded, target)
-    else
-      :not_a_path_target
-    end
-  end
-
-  defp resolve_existing_path(expanded, original_target) do
-    case existing_target_candidate(expanded) do
-      :missing ->
-        error(:run_target_not_found, "run not found: #{original_target}", target: original_target)
-
-      candidate ->
-        if run_dir?(candidate) do
-          {:ok, candidate}
-        else
-          error(
-            :invalid_run_target,
-            "not a ThinkTank run directory: #{original_target}",
-            target: original_target
-          )
-        end
-    end
-  end
-
-  defp existing_target_candidate(expanded) do
     cond do
-      File.dir?(expanded) -> expanded
-      File.exists?(expanded) -> run_dir_from_artifact_path(expanded)
-      true -> :missing
+      File.dir?(expanded) ->
+        validate_run_dir(expanded, target)
+
+      File.exists?(expanded) ->
+        expanded
+        |> run_dir_from_artifact_path()
+        |> validate_run_dir(target)
+
+      path_target?(target) ->
+        error(:run_target_not_found, "run not found: #{target}", target: target)
+
+      true ->
+        :not_a_path_target
     end
   end
 
@@ -184,6 +159,26 @@ defmodule Thinktank.RunInspector do
     end
   end
 
+  defp validate_run_dir(nil, original_target) do
+    error(
+      :invalid_run_target,
+      "not a ThinkTank run directory: #{original_target}",
+      target: original_target
+    )
+  end
+
+  defp validate_run_dir(output_dir, original_target) do
+    if run_dir?(output_dir) do
+      {:ok, output_dir}
+    else
+      error(
+        :invalid_run_target,
+        "not a ThinkTank run directory: #{original_target}",
+        target: original_target
+      )
+    end
+  end
+
   defp path_target?(target) do
     String.contains?(target, ["/", "\\"]) || String.starts_with?(target, ".") ||
       String.starts_with?(target, "~")
@@ -201,6 +196,36 @@ defmodule Thinktank.RunInspector do
     |> List.flatten()
     |> Enum.map(&Path.expand/1)
     |> Enum.uniq()
+  end
+
+  defp list_limit(opts) do
+    case Keyword.get(opts, :limit, @default_limit) do
+      nil ->
+        {:ok, nil}
+
+      limit when is_integer(limit) and limit >= 0 ->
+        {:ok, limit}
+
+      limit ->
+        error(:invalid_run_list_limit, "run list limit must be a non-negative integer",
+          limit: limit
+        )
+    end
+  end
+
+  defp load_listed_runs(opts, limit) do
+    opts
+    |> discover_output_dirs()
+    |> Enum.flat_map(&load_listed_run/1)
+    |> Enum.sort_by(&{sort_timestamp(&1), &1.id, &1.output_dir}, :desc)
+    |> maybe_limit(limit)
+  end
+
+  defp load_listed_run(output_dir) do
+    case load_run(output_dir, :lenient) do
+      {:ok, run} -> [run]
+      nil -> []
+    end
   end
 
   defp resolved_log_dir(opts) do
@@ -333,7 +358,7 @@ defmodule Thinktank.RunInspector do
          {:ok, decoded} <- decode_json_object(body, path) do
       {:ok, decoded}
     else
-      {:error, %{category: _} = reason} ->
+      {:error, %Error{} = reason} ->
         {:error, reason}
 
       {:error, reason} ->
@@ -363,7 +388,8 @@ defmodule Thinktank.RunInspector do
   end
 
   defp error(category, message, details \\ %{}) do
-    {:error, Map.merge(%{category: category, message: message}, Map.new(details))}
+    reason = Map.merge(%{category: category, message: message}, Map.new(details))
+    {:error, Error.from_reason(reason)}
   end
 
   defp build_run_info(output_dir, paths, manifest, summary, contract, status) do

--- a/lib/thinktank/run_inspector.ex
+++ b/lib/thinktank/run_inspector.ex
@@ -24,6 +24,12 @@ defmodule Thinktank.RunInspector do
           trace_events_file: String.t() | nil
         }
 
+  @type error_reason :: %{
+          required(:category) => atom(),
+          required(:message) => String.t(),
+          optional(atom()) => term()
+        }
+
   @spec list(keyword()) :: {:ok, [run_info()]}
   def list(opts \\ []) do
     limit = Keyword.get(opts, :limit, @default_limit)
@@ -40,14 +46,14 @@ defmodule Thinktank.RunInspector do
     {:ok, runs}
   end
 
-  @spec show(String.t(), keyword()) :: {:ok, run_info()} | {:error, String.t()}
+  @spec show(String.t(), keyword()) :: {:ok, run_info()} | {:error, error_reason()}
   def show(target, opts \\ []) when is_binary(target) do
     with {:ok, output_dir} <- resolve_target(target, opts) do
       load_run(output_dir)
     end
   end
 
-  @spec wait(String.t(), keyword()) :: {:ok, run_info()} | {:error, String.t()}
+  @spec wait(String.t(), keyword()) :: {:ok, run_info()} | {:error, error_reason()}
   def wait(target, opts \\ []) when is_binary(target) do
     poll_ms = Keyword.get(opts, :poll_ms, @default_poll_ms)
     timeout_ms = Keyword.get(opts, :timeout_ms, :infinity)
@@ -67,7 +73,9 @@ defmodule Thinktank.RunInspector do
 
       {:ok, _run} ->
         if timed_out?(deadline) do
-          {:error, "timed out waiting for run to finish: #{output_dir}"}
+          error(:run_wait_timeout, "timed out waiting for run to finish: #{output_dir}",
+            output_dir: output_dir
+          )
         else
           Process.sleep(poll_ms)
           wait_for_terminal(output_dir, poll_ms, deadline)
@@ -102,10 +110,14 @@ defmodule Thinktank.RunInspector do
         {:ok, output_dir}
 
       [] ->
-        {:error, "run not found: #{target}"}
+        error(:run_target_not_found, "run not found: #{target}", target: target)
 
       _ ->
-        {:error, "multiple runs match #{target}; use an explicit path"}
+        error(
+          :run_target_ambiguous,
+          "multiple runs match #{target}; use an explicit path",
+          target: target
+        )
     end
   end
 
@@ -122,13 +134,17 @@ defmodule Thinktank.RunInspector do
   defp resolve_existing_path(expanded, original_target) do
     case existing_target_candidate(expanded) do
       :missing ->
-        {:error, "run not found: #{original_target}"}
+        error(:run_target_not_found, "run not found: #{original_target}", target: original_target)
 
       candidate ->
         if run_dir?(candidate) do
           {:ok, candidate}
         else
-          {:error, "not a ThinkTank run directory: #{original_target}"}
+          error(
+            :invalid_run_target,
+            "not a ThinkTank run directory: #{original_target}",
+            target: original_target
+          )
         end
     end
   end
@@ -168,14 +184,30 @@ defmodule Thinktank.RunInspector do
   end
 
   defp discover_output_dirs(opts) do
+    tmp_dir = Keyword.get(opts, :tmp_dir, System.tmp_dir!())
+    log_dir = resolved_log_dir(opts)
+
     [
       tracked_output_dirs(),
-      tmp_output_dirs(Keyword.get(opts, :tmp_dir, System.tmp_dir!())),
-      log_output_dirs(Keyword.get(opts, :log_dir, TraceLog.global_log_dir()))
+      tmp_output_dirs(tmp_dir),
+      log_output_dirs(log_dir)
     ]
     |> List.flatten()
     |> Enum.map(&Path.expand/1)
     |> Enum.uniq()
+  end
+
+  defp resolved_log_dir(opts) do
+    case Keyword.fetch(opts, :log_dir) do
+      {:ok, log_dir} -> log_dir
+      :error -> safe_global_log_dir()
+    end
+  end
+
+  defp safe_global_log_dir do
+    TraceLog.global_log_dir()
+  rescue
+    _ -> nil
   end
 
   defp tracked_output_dirs do
@@ -249,15 +281,23 @@ defmodule Thinktank.RunInspector do
   end
 
   defp ensure_run_artifacts(output_dir, nil, nil, nil),
-    do: {:error, "run artifacts not found: #{output_dir}"}
+    do:
+      error(:run_artifacts_missing, "run artifacts not found: #{output_dir}",
+        output_dir: output_dir
+      )
 
   defp ensure_run_artifacts(_output_dir, _manifest, _summary, _contract), do: :ok
 
   defp derive_status(manifest, summary) do
     case manifest_value(manifest, "status") || manifest_value(summary, "status") do
-      status when status in @known_statuses -> {:ok, status}
-      nil -> {:error, "run status is missing"}
-      status -> {:error, "unknown run status: #{inspect(status)}"}
+      status when status in @known_statuses ->
+        {:ok, status}
+
+      nil ->
+        error(:run_status_missing, "run status is missing")
+
+      status ->
+        error(:run_status_invalid, "unknown run status: #{inspect(status)}", status: status)
     end
   end
 
@@ -270,20 +310,37 @@ defmodule Thinktank.RunInspector do
          {:ok, decoded} <- decode_json_object(body, path) do
       {:ok, decoded}
     else
-      {:error, reason} when is_binary(reason) ->
+      {:error, %{category: _} = reason} ->
         {:error, reason}
 
       {:error, reason} ->
-        {:error, "failed to read #{path}: #{:file.format_error(reason)}"}
+        error(
+          :run_artifact_read_error,
+          "failed to read #{path}: #{:file.format_error(reason)}",
+          path: path
+        )
     end
   end
 
   defp decode_json_object(body, path) do
     case Jason.decode(body) do
-      {:ok, decoded} when is_map(decoded) -> {:ok, decoded}
-      {:ok, _decoded} -> {:error, "expected JSON object at #{path}"}
-      {:error, reason} -> {:error, "failed to decode #{path}: #{Exception.message(reason)}"}
+      {:ok, decoded} when is_map(decoded) ->
+        {:ok, decoded}
+
+      {:ok, _decoded} ->
+        error(:run_artifact_invalid, "expected JSON object at #{path}", path: path)
+
+      {:error, reason} ->
+        error(
+          :run_artifact_decode_error,
+          "failed to decode #{path}: #{Exception.message(reason)}",
+          path: path
+        )
     end
+  end
+
+  defp error(category, message, details \\ %{}) do
+    {:error, Map.merge(%{category: category, message: message}, Map.new(details))}
   end
 
   defp build_run_info(output_dir, paths, manifest, summary, contract, status) do
@@ -302,7 +359,9 @@ defmodule Thinktank.RunInspector do
       completed_at:
         manifest_value(manifest, "completed_at") || manifest_value(summary, "completed_at"),
       workspace_root:
-        manifest_value(manifest, "workspace_root") || manifest_value(contract, "workspace_root"),
+        manifest_value(manifest, "workspace_root") ||
+          manifest_value(summary, "workspace_root") ||
+          manifest_value(contract, "workspace_root"),
       manifest_file: existing_path(paths.manifest),
       trace_summary_file: existing_path(paths.summary),
       trace_events_file: existing_path(paths.events)

--- a/lib/thinktank/run_inspector.ex
+++ b/lib/thinktank/run_inspector.ex
@@ -7,6 +7,12 @@ defmodule Thinktank.RunInspector do
 
   @known_statuses ~w(running complete degraded partial failed)
   @terminal_statuses ~w(complete degraded partial failed)
+  @transient_wait_error_codes [
+    :run_artifacts_missing,
+    :run_artifact_read_error,
+    :run_artifact_decode_error,
+    :run_status_missing
+  ]
   @default_poll_ms 100
   @default_limit 20
 
@@ -69,17 +75,24 @@ defmodule Thinktank.RunInspector do
         {:ok, run}
 
       {:ok, _run} ->
-        if timed_out?(deadline) do
-          error(:run_wait_timeout, "timed out waiting for run to finish: #{output_dir}",
-            output_dir: output_dir
-          )
-        else
-          Process.sleep(poll_ms)
-          wait_for_terminal(output_dir, poll_ms, deadline)
-        end
+        sleep_or_timeout(output_dir, poll_ms, deadline)
+
+      {:error, %Error{code: code}} when code in @transient_wait_error_codes ->
+        sleep_or_timeout(output_dir, poll_ms, deadline)
 
       {:error, _reason} = error ->
         error
+    end
+  end
+
+  defp sleep_or_timeout(output_dir, poll_ms, deadline) do
+    if timed_out?(deadline) do
+      error(:run_wait_timeout, "timed out waiting for run to finish: #{output_dir}",
+        output_dir: output_dir
+      )
+    else
+      Process.sleep(poll_ms)
+      wait_for_terminal(output_dir, poll_ms, deadline)
     end
   end
 

--- a/lib/thinktank/run_inspector.ex
+++ b/lib/thinktank/run_inspector.ex
@@ -30,20 +30,26 @@ defmodule Thinktank.RunInspector do
           optional(atom()) => term()
         }
 
-  @spec list(keyword()) :: {:ok, [run_info()]}
+  @spec list(keyword()) :: {:ok, [run_info()]} | {:error, error_reason()}
   def list(opts \\ []) do
     limit = Keyword.get(opts, :limit, @default_limit)
 
     runs =
       opts
       |> discover_output_dirs()
-      |> Enum.map(&load_run(&1, :lenient))
-      |> Enum.reject(&is_nil/1)
-      |> Enum.map(fn {:ok, run} -> run end)
+      |> Enum.flat_map(fn output_dir ->
+        case load_run(output_dir, :lenient) do
+          {:ok, run} -> [run]
+          nil -> []
+        end
+      end)
       |> Enum.sort_by(&{sort_timestamp(&1), &1.id, &1.output_dir}, :desc)
       |> maybe_limit(limit)
 
     {:ok, runs}
+  rescue
+    exception ->
+      error(:run_list_failed, "failed to discover runs", reason: Exception.message(exception))
   end
 
   @spec show(String.t(), keyword()) :: {:ok, run_info()} | {:error, error_reason()}
@@ -122,10 +128,10 @@ defmodule Thinktank.RunInspector do
   end
 
   defp resolve_target_path(target) do
-    if path_target?(target) do
-      target
-      |> Path.expand()
-      |> resolve_existing_path(target)
+    expanded = Path.expand(target)
+
+    if path_target?(target) || File.exists?(expanded) do
+      resolve_existing_path(expanded, target)
     else
       :not_a_path_target
     end
@@ -240,15 +246,16 @@ defmodule Thinktank.RunInspector do
   defp read_log_output_dirs(path) do
     path
     |> File.stream!(:line, [])
-    |> Enum.reduce([], fn line, acc ->
+    |> Enum.reduce(MapSet.new(), fn line, acc ->
       case Jason.decode(line) do
         {:ok, %{"output_dir" => output_dir}} when is_binary(output_dir) ->
-          [output_dir | acc]
+          MapSet.put(acc, output_dir)
 
         _ ->
           acc
       end
     end)
+    |> MapSet.to_list()
   rescue
     _ -> []
   end
@@ -289,16 +296,32 @@ defmodule Thinktank.RunInspector do
   defp ensure_run_artifacts(_output_dir, _manifest, _summary, _contract), do: :ok
 
   defp derive_status(manifest, summary) do
-    case manifest_value(manifest, "status") || manifest_value(summary, "status") do
-      status when status in @known_statuses ->
-        {:ok, status}
+    manifest_status = manifest_value(manifest, "status")
+    summary_status = manifest_value(summary, "status")
 
-      nil ->
-        error(:run_status_missing, "run status is missing")
+    with :ok <- validate_status(manifest_status),
+         :ok <- validate_status(summary_status) do
+      case preferred_status(manifest_status, summary_status) do
+        nil ->
+          error(:run_status_missing, "run status is missing")
 
-      status ->
-        error(:run_status_invalid, "unknown run status: #{inspect(status)}", status: status)
+        status ->
+          {:ok, status}
+      end
     end
+  end
+
+  defp preferred_status(_manifest_status, summary_status)
+       when summary_status in @terminal_statuses,
+       do: summary_status
+
+  defp preferred_status(manifest_status, summary_status), do: manifest_status || summary_status
+
+  defp validate_status(nil), do: :ok
+  defp validate_status(status) when status in @known_statuses, do: :ok
+
+  defp validate_status(status) do
+    error(:run_status_invalid, "unknown run status: #{inspect(status)}", status: status)
   end
 
   defp read_json_optional(path) do

--- a/lib/thinktank/run_inspector.ex
+++ b/lib/thinktank/run_inspector.ex
@@ -120,37 +120,41 @@ defmodule Thinktank.RunInspector do
   end
 
   defp resolve_existing_path(expanded, original_target) do
-    candidate =
-      cond do
-        File.dir?(expanded) -> expanded
-        File.exists?(expanded) -> run_dir_from_artifact_path(expanded)
-        true -> :missing
-      end
-
-    cond do
-      candidate == :missing ->
+    case existing_target_candidate(expanded) do
+      :missing ->
         {:error, "run not found: #{original_target}"}
 
-      run_dir?(candidate) ->
-        {:ok, candidate}
+      candidate ->
+        if run_dir?(candidate) do
+          {:ok, candidate}
+        else
+          {:error, "not a ThinkTank run directory: #{original_target}"}
+        end
+    end
+  end
 
-      true ->
-        {:error, "not a ThinkTank run directory: #{original_target}"}
+  defp existing_target_candidate(expanded) do
+    cond do
+      File.dir?(expanded) -> expanded
+      File.exists?(expanded) -> run_dir_from_artifact_path(expanded)
+      true -> :missing
     end
   end
 
   defp run_dir_from_artifact_path(path) do
+    trace_dir = TraceLog.summary_file() |> Path.dirname()
+    basename = Path.basename(path)
+    parent_dir = path |> Path.dirname() |> Path.basename()
+
     cond do
-      String.ends_with?(path, "/" <> ArtifactLayout.manifest_file()) ->
+      basename in [ArtifactLayout.manifest_file(), ArtifactLayout.contract_file()] ->
         Path.dirname(path)
 
-      String.ends_with?(path, "/" <> ArtifactLayout.contract_file()) ->
-        Path.dirname(path)
-
-      String.ends_with?(path, "/" <> TraceLog.summary_file()) ->
-        path |> Path.dirname() |> Path.dirname()
-
-      String.ends_with?(path, "/" <> TraceLog.events_file()) ->
+      parent_dir == trace_dir and
+          basename in [
+            Path.basename(TraceLog.summary_file()),
+            Path.basename(TraceLog.events_file())
+          ] ->
         path |> Path.dirname() |> Path.dirname()
 
       true ->
@@ -217,10 +221,12 @@ defmodule Thinktank.RunInspector do
     _ -> []
   end
 
-  defp run_dir?(output_dir) do
+  defp run_dir?(output_dir) when is_binary(output_dir) do
     File.exists?(Path.join(output_dir, ArtifactLayout.manifest_file())) ||
       File.exists?(Path.join(output_dir, TraceLog.summary_file()))
   end
+
+  defp run_dir?(_), do: false
 
   defp load_run(output_dir, mode \\ :strict) do
     case do_load_run(Path.expand(output_dir)) do

--- a/lib/thinktank/trace_log.ex
+++ b/lib/thinktank/trace_log.ex
@@ -82,6 +82,20 @@ defmodule Thinktank.TraceLog do
   @spec summary_file() :: String.t()
   def summary_file, do: @summary_file
 
+  @spec global_log_dir() :: String.t() | nil
+  def global_log_dir do
+    case System.get_env("THINKTANK_LOG_DIR") do
+      value when value in [nil, ""] ->
+        default_log_dir()
+
+      "off" ->
+        nil
+
+      value ->
+        Path.expand(value)
+    end
+  end
+
   defp ensure_initialized(output_dir) do
     unless File.exists?(summary_path(output_dir)) do
       init_run(output_dir)
@@ -205,19 +219,6 @@ defmodule Thinktank.TraceLog do
           |> Date.to_iso8601()
 
         Path.join(dir, "#{date}.jsonl")
-    end
-  end
-
-  defp global_log_dir do
-    case System.get_env("THINKTANK_LOG_DIR") do
-      value when value in [nil, ""] ->
-        default_log_dir()
-
-      "off" ->
-        nil
-
-      value ->
-        Path.expand(value)
     end
   end
 

--- a/test/thinktank/cli_test.exs
+++ b/test/thinktank/cli_test.exs
@@ -507,6 +507,21 @@ defmodule Thinktank.CLITest do
     assert output =~ "Output: #{output_dir}"
   end
 
+  test "runs show --json emits the run envelope" do
+    output_dir = init_run_fixture("thinktank-cli-runs-show-json", "research/default", "failed")
+
+    {:ok, command} = CLI.parse_args(["runs", "show", output_dir, "--json"])
+
+    output =
+      capture_io(fn ->
+        assert CLI.execute({:ok, command}) == @exit_codes.success
+      end)
+
+    assert {:ok, decoded} = Jason.decode(String.trim(output))
+    assert decoded["run"]["status"] == "failed"
+    assert decoded["run"]["output_dir"] == output_dir
+  end
+
   test "runs wait exits non-zero when the final run status is not complete" do
     output_dir = init_run_fixture("thinktank-cli-runs-wait", "research/default", "partial")
 
@@ -518,6 +533,21 @@ defmodule Thinktank.CLITest do
       end)
 
     assert output =~ "Status: partial"
+  end
+
+  test "runs wait --json preserves the run envelope on non-complete terminal state" do
+    output_dir = init_run_fixture("thinktank-cli-runs-wait-json", "research/default", "partial")
+
+    {:ok, command} = CLI.parse_args(["runs", "wait", output_dir, "--json"])
+
+    output =
+      capture_io(fn ->
+        assert CLI.execute({:ok, command}) == @exit_codes.generic_error
+      end)
+
+    assert {:ok, decoded} = Jason.decode(String.trim(output))
+    assert decoded["run"]["status"] == "partial"
+    assert decoded["run"]["output_dir"] == output_dir
   end
 
   test "renders a cost line in the human-readable run payload" do

--- a/test/thinktank/cli_test.exs
+++ b/test/thinktank/cli_test.exs
@@ -536,6 +536,28 @@ defmodule Thinktank.CLITest do
     assert stderr =~ "Error: not a ThinkTank run directory: #{path}"
   end
 
+  test "runs show returns a generic error for malformed run artifacts" do
+    output_dir =
+      init_run_fixture("thinktank-cli-runs-show-invalid-artifact", "research/default", "complete")
+
+    manifest_path = Path.join(output_dir, "manifest.json")
+
+    manifest_path
+    |> File.read!()
+    |> Jason.decode!()
+    |> Map.put("status", "mystery")
+    |> then(&File.write!(manifest_path, Jason.encode!(&1, pretty: true)))
+
+    {:ok, command} = CLI.parse_args(["runs", "show", output_dir])
+
+    stderr =
+      capture_io(:stderr, fn ->
+        assert CLI.execute({:ok, command}) == @exit_codes.generic_error
+      end)
+
+    assert stderr =~ "Error: unknown run status: \"mystery\""
+  end
+
   test "runs wait exits non-zero when the final run status is not complete" do
     output_dir = init_run_fixture("thinktank-cli-runs-wait", "research/default", "partial")
 
@@ -562,6 +584,20 @@ defmodule Thinktank.CLITest do
     assert {:ok, decoded} = Jason.decode(String.trim(output))
     assert decoded["run"]["status"] == "partial"
     assert decoded["run"]["output_dir"] == output_dir
+  end
+
+  test "runs wait returns an input error for an existing non-run file target" do
+    path = Path.join(unique_tmp_dir("thinktank-cli-runs-wait-invalid-file"), "notes.txt")
+    File.write!(path, "not a run")
+
+    {:ok, command} = CLI.parse_args(["runs", "wait", path])
+
+    stderr =
+      capture_io(:stderr, fn ->
+        assert CLI.execute({:ok, command}) == @exit_codes.input_error
+      end)
+
+    assert stderr =~ "Error: not a ThinkTank run directory: #{path}"
   end
 
   test "renders a cost line in the human-readable run payload" do

--- a/test/thinktank/cli_test.exs
+++ b/test/thinktank/cli_test.exs
@@ -522,6 +522,20 @@ defmodule Thinktank.CLITest do
     assert decoded["run"]["output_dir"] == output_dir
   end
 
+  test "runs show returns an input error for an existing non-run file target" do
+    path = Path.join(unique_tmp_dir("thinktank-cli-runs-show-invalid-file"), "notes.txt")
+    File.write!(path, "not a run")
+
+    {:ok, command} = CLI.parse_args(["runs", "show", path])
+
+    stderr =
+      capture_io(:stderr, fn ->
+        assert CLI.execute({:ok, command}) == @exit_codes.input_error
+      end)
+
+    assert stderr =~ "Error: not a ThinkTank run directory: #{path}"
+  end
+
   test "runs wait exits non-zero when the final run status is not complete" do
     output_dir = init_run_fixture("thinktank-cli-runs-wait", "research/default", "partial")
 

--- a/test/thinktank/cli_test.exs
+++ b/test/thinktank/cli_test.exs
@@ -3,7 +3,7 @@ defmodule Thinktank.CLITest do
 
   import ExUnit.CaptureIO
 
-  alias Thinktank.{CLI, Config}
+  alias Thinktank.{BenchSpec, CLI, Config, RunContract, RunStore}
 
   @exit_codes CLI.exit_codes()
 
@@ -204,6 +204,16 @@ defmodule Thinktank.CLITest do
              CLI.parse_args(["workflows", "show", "review/default"])
   end
 
+  test "parses run inspection commands" do
+    assert {:ok, %{action: :runs_list, json: true}} = CLI.parse_args(["runs", "list", "--json"])
+
+    assert {:ok, %{action: :runs_show, target: "abc123"}} =
+             CLI.parse_args(["runs", "show", "abc123"])
+
+    assert {:ok, %{action: :runs_wait, target: "./tmp/run"}} =
+             CLI.parse_args(["runs", "wait", "./tmp/run"])
+  end
+
   test "benches validate prints JSON when --json is requested" do
     {:ok, config} = Config.load()
     expected_count = length(Config.list_benches(config))
@@ -299,6 +309,9 @@ defmodule Thinktank.CLITest do
 
     assert {:error, "benches expects list, show <bench>, or validate"} =
              CLI.parse_args(["benches", "show", "research/default", "extra"])
+
+    assert {:error, "runs expects list, show <path-or-id>, or wait <path-or-id>"} =
+             CLI.parse_args(["runs", "show"])
   end
 
   test "read_stdin fails fast when stdin is interactive" do
@@ -456,7 +469,55 @@ defmodule Thinktank.CLITest do
 
     assert output =~ "thinktank benches"
     assert output =~ "thinktank review"
+    assert output =~ "thinktank runs"
     assert output =~ "Task text can come from --input, positional text, or piped stdin."
+  end
+
+  test "runs list --json emits discovered runs with typed state" do
+    output_dir = init_run_fixture("thinktank-cli-runs-list", "review/default", "degraded")
+    run_id = Path.basename(output_dir)
+
+    {:ok, command} = CLI.parse_args(["runs", "list", "--json"])
+
+    output =
+      capture_io(fn ->
+        assert CLI.execute({:ok, command}) == @exit_codes.success
+      end)
+
+    assert {:ok, decoded} = Jason.decode(String.trim(output))
+    assert is_list(decoded["runs"])
+
+    run = Enum.find(decoded["runs"], &(&1["id"] == run_id))
+    assert run["bench"] == "review/default"
+    assert run["status"] == "degraded"
+    assert run["output_dir"] == output_dir
+  end
+
+  test "runs show prints terminal status without treating failed runs as CLI errors" do
+    output_dir = init_run_fixture("thinktank-cli-runs-show", "research/default", "failed")
+
+    {:ok, command} = CLI.parse_args(["runs", "show", output_dir])
+
+    output =
+      capture_io(fn ->
+        assert CLI.execute({:ok, command}) == @exit_codes.success
+      end)
+
+    assert output =~ "Status: failed"
+    assert output =~ "Output: #{output_dir}"
+  end
+
+  test "runs wait exits non-zero when the final run status is not complete" do
+    output_dir = init_run_fixture("thinktank-cli-runs-wait", "research/default", "partial")
+
+    {:ok, command} = CLI.parse_args(["runs", "wait", output_dir])
+
+    output =
+      capture_io(fn ->
+        assert CLI.execute({:ok, command}) == @exit_codes.generic_error
+      end)
+
+    assert output =~ "Status: partial"
   end
 
   test "renders a cost line in the human-readable run payload" do
@@ -513,6 +574,24 @@ defmodule Thinktank.CLITest do
     research = Enum.find(decoded, &(&1["id"] == "research/default"))
     assert research["kind"] == "research"
     assert research["agent_count"] == 4
+  end
+
+  defp init_run_fixture(prefix, bench_id, status) do
+    output_dir = Path.join(unique_tmp_dir(prefix), "run")
+
+    contract = %RunContract{
+      bench_id: bench_id,
+      workspace_root: File.cwd!(),
+      input: %{"input_text" => "inspect this"},
+      artifact_dir: output_dir,
+      adapter_context: %{}
+    }
+
+    bench = %BenchSpec{id: bench_id, description: "Demo", agents: ["systems"]}
+
+    RunStore.init_run(output_dir, contract, bench)
+    RunStore.complete_run(output_dir, status)
+    output_dir
   end
 
   test "benches list without --json emits tab-separated text" do

--- a/test/thinktank/cli_test.exs
+++ b/test/thinktank/cli_test.exs
@@ -210,8 +210,11 @@ defmodule Thinktank.CLITest do
     assert {:ok, %{action: :runs_show, target: "abc123"}} =
              CLI.parse_args(["runs", "show", "abc123"])
 
-    assert {:ok, %{action: :runs_wait, target: "./tmp/run"}} =
-             CLI.parse_args(["runs", "wait", "./tmp/run"])
+    assert {:ok, %{action: :runs_wait, target: "./tmp/run", timeout_ms: 250}} =
+             CLI.parse_args(["runs", "wait", "./tmp/run", "--timeout-ms", "250"])
+
+    assert {:error, "--timeout-ms must be a non-negative integer"} =
+             CLI.parse_args(["runs", "wait", "./tmp/run", "--timeout-ms", "-1"])
   end
 
   test "benches validate prints JSON when --json is requested" do
@@ -493,6 +496,17 @@ defmodule Thinktank.CLITest do
     assert run["output_dir"] == output_dir
   end
 
+  test "runs list returns an input error for invalid internal limit" do
+    command = %{action: :runs_list, cwd: File.cwd!(), json: false, limit: -1}
+
+    stderr =
+      capture_io(:stderr, fn ->
+        assert CLI.execute({:ok, command}) == @exit_codes.input_error
+      end)
+
+    assert stderr =~ "Error: run list limit must be a non-negative integer"
+  end
+
   test "runs show prints terminal status without treating failed runs as CLI errors" do
     output_dir = init_run_fixture("thinktank-cli-runs-show", "research/default", "failed")
 
@@ -598,6 +612,56 @@ defmodule Thinktank.CLITest do
       end)
 
     assert stderr =~ "Error: not a ThinkTank run directory: #{path}"
+  end
+
+  test "runs wait supports bounded polling with --timeout-ms" do
+    output_dir = Path.join(unique_tmp_dir("thinktank-cli-runs-wait-timeout"), "run")
+
+    contract = %RunContract{
+      bench_id: "research/default",
+      workspace_root: File.cwd!(),
+      input: %{"input_text" => "inspect this"},
+      artifact_dir: output_dir,
+      adapter_context: %{}
+    }
+
+    bench = %BenchSpec{id: "research/default", description: "Demo", agents: ["systems"]}
+    RunStore.init_run(output_dir, contract, bench)
+
+    {:ok, command} = CLI.parse_args(["runs", "wait", output_dir, "--timeout-ms", "0"])
+
+    stderr =
+      capture_io(:stderr, fn ->
+        assert CLI.execute({:ok, command}) == @exit_codes.generic_error
+      end)
+
+    assert stderr =~ "Error: timed out waiting for run to finish: #{output_dir}"
+  end
+
+  test "runs wait --json includes output_dir in timeout errors" do
+    output_dir = Path.join(unique_tmp_dir("thinktank-cli-runs-wait-timeout-json"), "run")
+
+    contract = %RunContract{
+      bench_id: "research/default",
+      workspace_root: File.cwd!(),
+      input: %{"input_text" => "inspect this"},
+      artifact_dir: output_dir,
+      adapter_context: %{}
+    }
+
+    bench = %BenchSpec{id: "research/default", description: "Demo", agents: ["systems"]}
+    RunStore.init_run(output_dir, contract, bench)
+
+    {:ok, command} = CLI.parse_args(["runs", "wait", output_dir, "--timeout-ms", "0", "--json"])
+
+    stderr =
+      capture_io(:stderr, fn ->
+        assert CLI.execute({:ok, command}) == @exit_codes.generic_error
+      end)
+
+    assert {:ok, decoded} = Jason.decode(String.trim(stderr))
+    assert decoded["output_dir"] == output_dir
+    assert decoded["error"]["code"] == "run_wait_timeout"
   end
 
   test "renders a cost line in the human-readable run payload" do

--- a/test/thinktank/run_inspector_test.exs
+++ b/test/thinktank/run_inspector_test.exs
@@ -1,7 +1,7 @@
 defmodule Thinktank.RunInspectorTest do
   use ExUnit.Case, async: false
 
-  alias Thinktank.{BenchSpec, RunContract, RunInspector, RunStore, RunTracker}
+  alias Thinktank.{BenchSpec, Error, RunContract, RunInspector, RunStore, RunTracker}
 
   defp unique_tmp_dir(prefix) do
     dir = Path.join(System.tmp_dir!(), "#{prefix}-#{System.unique_integer([:positive])}")
@@ -192,10 +192,10 @@ defmodule Thinktank.RunInspectorTest do
   test "show returns a typed error for a missing run target" do
     missing = Path.join(unique_tmp_dir("thinktank-run-inspector-missing"), "missing-run")
 
-    assert {:error, %{category: :run_target_not_found, message: "run not found: " <> ^missing}} =
+    assert {:error, %Error{code: :run_target_not_found, message: "run not found: " <> ^missing}} =
              RunInspector.show(missing)
 
-    assert {:error, %{category: :run_target_not_found, message: "run not found: no-such-run"}} =
+    assert {:error, %Error{code: :run_target_not_found, message: "run not found: no-such-run"}} =
              RunInspector.show("no-such-run")
   end
 
@@ -203,7 +203,7 @@ defmodule Thinktank.RunInspectorTest do
     dir = unique_tmp_dir("thinktank-run-inspector-non-run")
 
     assert {:error,
-            %{category: :invalid_run_target, message: "not a ThinkTank run directory: " <> ^dir}} =
+            %Error{code: :invalid_run_target, message: "not a ThinkTank run directory: " <> ^dir}} =
              RunInspector.show(dir)
   end
 
@@ -217,7 +217,7 @@ defmodule Thinktank.RunInspectorTest do
     File.write!(path, "not a run")
 
     assert {:error,
-            %{category: :invalid_run_target, message: "not a ThinkTank run directory: " <> ^path}} =
+            %Error{code: :invalid_run_target, message: "not a ThinkTank run directory: " <> ^path}} =
              RunInspector.show(path)
   end
 
@@ -227,13 +227,17 @@ defmodule Thinktank.RunInspectorTest do
 
     update_json(Path.join(output_dir, "manifest.json"), &Map.put(&1, "status", "mystery"))
 
-    assert {:error, %{category: :run_status_invalid, message: "unknown run status: \"mystery\""}} =
+    assert {:error, %Error{code: :run_status_invalid, message: "unknown run status: \"mystery\""}} =
              RunInspector.show(output_dir)
   end
 
-  test "list returns a typed error when run discovery raises unexpectedly" do
-    assert {:error, %{category: :run_list_failed, message: "failed to discover runs"}} =
-             RunInspector.list(tmp_dir: :invalid)
+  test "list returns a typed error for an invalid limit option" do
+    assert {:error,
+            %Error{
+              code: :invalid_run_list_limit,
+              message: "run list limit must be a non-negative integer"
+            }} =
+             RunInspector.list(limit: -1)
   end
 
   test "show returns a typed error when multiple runs share the same id" do
@@ -247,8 +251,8 @@ defmodule Thinktank.RunInspectorTest do
     RunStore.complete_run(second_dir, "degraded")
 
     assert {:error,
-            %{
-              category: :run_target_ambiguous,
+            %Error{
+              code: :run_target_ambiguous,
               message: "multiple runs match " <> ^run_id <> "; use an explicit path"
             }} =
              RunInspector.show(run_id)
@@ -278,8 +282,8 @@ defmodule Thinktank.RunInspectorTest do
     RunTracker.start(output_dir, %{"bench" => "research/default"})
 
     assert {:error,
-            %{
-              category: :run_wait_timeout,
+            %Error{
+              code: :run_wait_timeout,
               message: "timed out waiting for run to finish: " <> ^output_dir
             }} =
              RunInspector.wait(output_dir, poll_ms: 5, timeout_ms: 0)

--- a/test/thinktank/run_inspector_test.exs
+++ b/test/thinktank/run_inspector_test.exs
@@ -104,6 +104,22 @@ defmodule Thinktank.RunInspectorTest do
     assert run.status == "complete"
   end
 
+  test "show preserves workspace_root for summary-only runs" do
+    output_dir = Path.join(unique_tmp_dir("thinktank-run-inspector-summary-only"), "run")
+    expected_root = File.cwd!()
+
+    init_run(output_dir, "research/default")
+    RunStore.complete_run(output_dir, "complete")
+
+    File.rm!(Path.join(output_dir, "manifest.json"))
+    File.rm!(Path.join(output_dir, "contract.json"))
+
+    assert {:ok, run} = RunInspector.show(output_dir)
+    assert run.workspace_root == expected_root
+    assert run.manifest_file == nil
+    assert run.trace_summary_file == Path.join(output_dir, "trace/summary.json")
+  end
+
   test "list returns recent runs sorted by started_at descending" do
     first_dir = Path.join(unique_tmp_dir("thinktank-run-inspector-list-first"), "first")
     init_run(first_dir, "research/default")
@@ -143,14 +159,19 @@ defmodule Thinktank.RunInspectorTest do
   test "show returns a typed error for a missing run target" do
     missing = Path.join(unique_tmp_dir("thinktank-run-inspector-missing"), "missing-run")
 
-    assert {:error, "run not found: " <> ^missing} = RunInspector.show(missing)
-    assert {:error, "run not found: no-such-run"} = RunInspector.show("no-such-run")
+    assert {:error, %{category: :run_target_not_found, message: "run not found: " <> ^missing}} =
+             RunInspector.show(missing)
+
+    assert {:error, %{category: :run_target_not_found, message: "run not found: no-such-run"}} =
+             RunInspector.show("no-such-run")
   end
 
   test "show returns a typed error for a non-run directory" do
     dir = unique_tmp_dir("thinktank-run-inspector-non-run")
 
-    assert {:error, "not a ThinkTank run directory: " <> ^dir} = RunInspector.show(dir)
+    assert {:error,
+            %{category: :invalid_run_target, message: "not a ThinkTank run directory: " <> ^dir}} =
+             RunInspector.show(dir)
   end
 
   test "show returns a typed error for an existing non-run file" do
@@ -162,7 +183,9 @@ defmodule Thinktank.RunInspectorTest do
 
     File.write!(path, "not a run")
 
-    assert {:error, "not a ThinkTank run directory: " <> ^path} = RunInspector.show(path)
+    assert {:error,
+            %{category: :invalid_run_target, message: "not a ThinkTank run directory: " <> ^path}} =
+             RunInspector.show(path)
   end
 
   test "show returns a typed error when the run status is unknown" do
@@ -171,7 +194,8 @@ defmodule Thinktank.RunInspectorTest do
 
     update_json(Path.join(output_dir, "manifest.json"), &Map.put(&1, "status", "mystery"))
 
-    assert {:error, "unknown run status: \"mystery\""} = RunInspector.show(output_dir)
+    assert {:error, %{category: :run_status_invalid, message: "unknown run status: \"mystery\""}} =
+             RunInspector.show(output_dir)
   end
 
   test "show returns a typed error when multiple runs share the same id" do
@@ -184,7 +208,11 @@ defmodule Thinktank.RunInspectorTest do
     init_run(second_dir, "review/default")
     RunStore.complete_run(second_dir, "degraded")
 
-    assert {:error, "multiple runs match " <> ^run_id <> "; use an explicit path"} =
+    assert {:error,
+            %{
+              category: :run_target_ambiguous,
+              message: "multiple runs match " <> ^run_id <> "; use an explicit path"
+            }} =
              RunInspector.show(run_id)
   end
 
@@ -211,7 +239,11 @@ defmodule Thinktank.RunInspectorTest do
     init_run(output_dir, "research/default")
     RunTracker.start(output_dir, %{"bench" => "research/default"})
 
-    assert {:error, "timed out waiting for run to finish: " <> ^output_dir} =
+    assert {:error,
+            %{
+              category: :run_wait_timeout,
+              message: "timed out waiting for run to finish: " <> ^output_dir
+            }} =
              RunInspector.wait(output_dir, poll_ms: 5, timeout_ms: 0)
   end
 end

--- a/test/thinktank/run_inspector_test.exs
+++ b/test/thinktank/run_inspector_test.exs
@@ -153,6 +153,18 @@ defmodule Thinktank.RunInspectorTest do
     assert {:error, "not a ThinkTank run directory: " <> ^dir} = RunInspector.show(dir)
   end
 
+  test "show returns a typed error for an existing non-run file" do
+    path =
+      Path.join(
+        unique_tmp_dir("thinktank-run-inspector-non-run-file"),
+        "notes.txt"
+      )
+
+    File.write!(path, "not a run")
+
+    assert {:error, "not a ThinkTank run directory: " <> ^path} = RunInspector.show(path)
+  end
+
   test "show returns a typed error when the run status is unknown" do
     output_dir = Path.join(unique_tmp_dir("thinktank-run-inspector-unknown-status"), "run")
     init_run(output_dir, "research/default")

--- a/test/thinktank/run_inspector_test.exs
+++ b/test/thinktank/run_inspector_test.exs
@@ -1,0 +1,128 @@
+defmodule Thinktank.RunInspectorTest do
+  use ExUnit.Case, async: false
+
+  alias Thinktank.{BenchSpec, RunContract, RunInspector, RunStore, RunTracker}
+
+  defp unique_tmp_dir(prefix) do
+    dir = Path.join(System.tmp_dir!(), "#{prefix}-#{System.unique_integer([:positive])}")
+    File.rm_rf!(dir)
+    File.mkdir_p!(dir)
+    dir
+  end
+
+  defp init_run(output_dir, bench_id) do
+    contract = %RunContract{
+      bench_id: bench_id,
+      workspace_root: File.cwd!(),
+      input: %{"input_text" => "inspect this"},
+      artifact_dir: output_dir,
+      adapter_context: %{}
+    }
+
+    bench = %BenchSpec{id: bench_id, description: "Demo", agents: ["systems"]}
+
+    RunStore.init_run(output_dir, contract, bench)
+  end
+
+  setup do
+    log_dir = unique_tmp_dir("thinktank-run-inspector-logs")
+    previous = System.get_env("THINKTANK_LOG_DIR")
+    System.put_env("THINKTANK_LOG_DIR", log_dir)
+
+    on_exit(fn ->
+      if previous do
+        System.put_env("THINKTANK_LOG_DIR", previous)
+      else
+        System.delete_env("THINKTANK_LOG_DIR")
+      end
+
+      Enum.each(RunTracker.active_runs(), fn {output_dir, _attrs} ->
+        RunTracker.unregister(output_dir)
+      end)
+    end)
+
+    %{log_dir: log_dir}
+  end
+
+  for {status, bench_id} <- [
+        {"complete", "research/default"},
+        {"degraded", "review/default"},
+        {"partial", "research/default"},
+        {"failed", "review/default"}
+      ] do
+    test "show reports #{status} terminal state" do
+      output_dir =
+        Path.join(unique_tmp_dir("thinktank-run-inspector-#{unquote(status)}"), "run")
+
+      init_run(output_dir, unquote(bench_id))
+      RunStore.complete_run(output_dir, unquote(status))
+
+      assert {:ok, run} = RunInspector.show(output_dir)
+      assert run.status == unquote(status)
+      assert run.output_dir == Path.expand(output_dir)
+      assert run.id == Path.basename(output_dir)
+      assert run.bench == unquote(bench_id)
+    end
+  end
+
+  test "show reports running state for an initialized active run" do
+    output_dir = Path.join(unique_tmp_dir("thinktank-run-inspector-running"), "run")
+    init_run(output_dir, "research/default")
+    RunTracker.start(output_dir, %{"bench" => "research/default"})
+
+    assert {:ok, run} = RunInspector.show(output_dir)
+    assert run.status == "running"
+    assert run.completed_at == nil
+  end
+
+  test "show resolves a run by id discovered from the global trace log" do
+    run_id = "custom-run-#{System.unique_integer([:positive])}"
+    parent = Path.join(System.tmp_dir!(), "custom-parent-#{System.unique_integer([:positive])}")
+    File.rm_rf!(parent)
+    File.mkdir_p!(parent)
+    output_dir = Path.join(parent, run_id)
+
+    init_run(output_dir, "research/default")
+    RunTracker.start(output_dir, %{"bench" => "research/default"})
+    RunTracker.finish(output_dir, "complete", %{"bench" => "research/default"})
+
+    assert {:ok, run} = RunInspector.show(run_id)
+    assert run.output_dir == Path.expand(output_dir)
+    assert run.status == "complete"
+  end
+
+  test "list returns recent runs sorted by started_at descending" do
+    first_dir = Path.join(unique_tmp_dir("thinktank-run-inspector-list-first"), "first")
+    init_run(first_dir, "research/default")
+    RunStore.complete_run(first_dir, "complete")
+    Process.sleep(10)
+
+    second_dir = Path.join(unique_tmp_dir("thinktank-run-inspector-list-second"), "second")
+    init_run(second_dir, "review/default")
+    RunStore.complete_run(second_dir, "degraded")
+
+    assert {:ok, runs} = RunInspector.list(limit: nil)
+    ids = Enum.map(runs, & &1.id)
+    assert Enum.find(runs, &(&1.output_dir == Path.expand(first_dir))).status == "complete"
+    assert Enum.find(runs, &(&1.output_dir == Path.expand(second_dir))).status == "degraded"
+    assert Enum.find_index(ids, &(&1 == "second")) < Enum.find_index(ids, &(&1 == "first"))
+  end
+
+  test "wait blocks until the run reaches a terminal state" do
+    output_dir = Path.join(unique_tmp_dir("thinktank-run-inspector-wait"), "run")
+    init_run(output_dir, "research/default")
+    RunTracker.start(output_dir, %{"bench" => "research/default"})
+
+    parent = self()
+
+    Task.start(fn ->
+      Process.sleep(50)
+      RunTracker.finish(output_dir, "complete", %{"bench" => "research/default"})
+      send(parent, :finished)
+    end)
+
+    assert {:ok, run} = RunInspector.wait(output_dir, poll_ms: 10, timeout_ms: 1_000)
+    assert run.status == "complete"
+    assert_receive :finished, 1_000
+  end
+end

--- a/test/thinktank/run_inspector_test.exs
+++ b/test/thinktank/run_inspector_test.exs
@@ -276,6 +276,26 @@ defmodule Thinktank.RunInspectorTest do
     assert_receive :finished, 1_000
   end
 
+  test "wait retries transient artifact load errors for tracked active runs" do
+    run_id = "pending-run-#{System.unique_integer([:positive])}"
+    output_dir = Path.join(unique_tmp_dir("thinktank-run-inspector-pending-wait"), run_id)
+    RunTracker.start(output_dir, %{"bench" => "research/default"})
+
+    parent = self()
+
+    Task.start(fn ->
+      Process.sleep(50)
+      init_run(output_dir, "research/default")
+      RunTracker.finish(output_dir, "complete", %{"bench" => "research/default"})
+      send(parent, :finished)
+    end)
+
+    assert {:ok, run} = RunInspector.wait(run_id, poll_ms: 10, timeout_ms: 1_000)
+    assert run.output_dir == Path.expand(output_dir)
+    assert run.status == "complete"
+    assert_receive :finished, 1_000
+  end
+
   test "wait returns a typed timeout error while the run is still active" do
     output_dir = Path.join(unique_tmp_dir("thinktank-run-inspector-timeout"), "run")
     init_run(output_dir, "research/default")

--- a/test/thinktank/run_inspector_test.exs
+++ b/test/thinktank/run_inspector_test.exs
@@ -24,6 +24,19 @@ defmodule Thinktank.RunInspectorTest do
     RunStore.init_run(output_dir, contract, bench)
   end
 
+  defp read_json(path), do: path |> File.read!() |> Jason.decode!()
+
+  defp write_json(path, data) do
+    File.write!(path, Jason.encode!(data, pretty: true))
+  end
+
+  defp update_json(path, fun) do
+    path
+    |> read_json()
+    |> fun.()
+    |> then(&write_json(path, &1))
+  end
+
   setup do
     log_dir = unique_tmp_dir("thinktank-run-inspector-logs")
     previous = System.get_env("THINKTANK_LOG_DIR")
@@ -95,17 +108,72 @@ defmodule Thinktank.RunInspectorTest do
     first_dir = Path.join(unique_tmp_dir("thinktank-run-inspector-list-first"), "first")
     init_run(first_dir, "research/default")
     RunStore.complete_run(first_dir, "complete")
-    Process.sleep(10)
 
     second_dir = Path.join(unique_tmp_dir("thinktank-run-inspector-list-second"), "second")
     init_run(second_dir, "review/default")
     RunStore.complete_run(second_dir, "degraded")
+
+    update_json(
+      Path.join(first_dir, "manifest.json"),
+      &Map.put(&1, "started_at", "2026-01-01T00:00:00Z")
+    )
+
+    update_json(
+      Path.join(second_dir, "manifest.json"),
+      &Map.put(&1, "started_at", "2026-01-02T00:00:00Z")
+    )
 
     assert {:ok, runs} = RunInspector.list(limit: nil)
     ids = Enum.map(runs, & &1.id)
     assert Enum.find(runs, &(&1.output_dir == Path.expand(first_dir))).status == "complete"
     assert Enum.find(runs, &(&1.output_dir == Path.expand(second_dir))).status == "degraded"
     assert Enum.find_index(ids, &(&1 == "second")) < Enum.find_index(ids, &(&1 == "first"))
+  end
+
+  test "show accepts a manifest path and resolves the containing run" do
+    output_dir = Path.join(unique_tmp_dir("thinktank-run-inspector-manifest"), "run")
+    init_run(output_dir, "research/default")
+    RunStore.complete_run(output_dir, "complete")
+
+    assert {:ok, run} = RunInspector.show(Path.join(output_dir, "manifest.json"))
+    assert run.output_dir == Path.expand(output_dir)
+    assert run.status == "complete"
+  end
+
+  test "show returns a typed error for a missing run target" do
+    missing = Path.join(unique_tmp_dir("thinktank-run-inspector-missing"), "missing-run")
+
+    assert {:error, "run not found: " <> ^missing} = RunInspector.show(missing)
+    assert {:error, "run not found: no-such-run"} = RunInspector.show("no-such-run")
+  end
+
+  test "show returns a typed error for a non-run directory" do
+    dir = unique_tmp_dir("thinktank-run-inspector-non-run")
+
+    assert {:error, "not a ThinkTank run directory: " <> ^dir} = RunInspector.show(dir)
+  end
+
+  test "show returns a typed error when the run status is unknown" do
+    output_dir = Path.join(unique_tmp_dir("thinktank-run-inspector-unknown-status"), "run")
+    init_run(output_dir, "research/default")
+
+    update_json(Path.join(output_dir, "manifest.json"), &Map.put(&1, "status", "mystery"))
+
+    assert {:error, "unknown run status: \"mystery\""} = RunInspector.show(output_dir)
+  end
+
+  test "show returns a typed error when multiple runs share the same id" do
+    run_id = "duplicate-run-#{System.unique_integer([:positive])}"
+    first_dir = Path.join(unique_tmp_dir("thinktank-run-inspector-duplicate-first"), run_id)
+    second_dir = Path.join(unique_tmp_dir("thinktank-run-inspector-duplicate-second"), run_id)
+
+    init_run(first_dir, "research/default")
+    RunStore.complete_run(first_dir, "complete")
+    init_run(second_dir, "review/default")
+    RunStore.complete_run(second_dir, "degraded")
+
+    assert {:error, "multiple runs match " <> ^run_id <> "; use an explicit path"} =
+             RunInspector.show(run_id)
   end
 
   test "wait blocks until the run reaches a terminal state" do
@@ -124,5 +192,14 @@ defmodule Thinktank.RunInspectorTest do
     assert {:ok, run} = RunInspector.wait(output_dir, poll_ms: 10, timeout_ms: 1_000)
     assert run.status == "complete"
     assert_receive :finished, 1_000
+  end
+
+  test "wait returns a typed timeout error while the run is still active" do
+    output_dir = Path.join(unique_tmp_dir("thinktank-run-inspector-timeout"), "run")
+    init_run(output_dir, "research/default")
+    RunTracker.start(output_dir, %{"bench" => "research/default"})
+
+    assert {:error, "timed out waiting for run to finish: " <> ^output_dir} =
+             RunInspector.wait(output_dir, poll_ms: 5, timeout_ms: 0)
   end
 end

--- a/test/thinktank/run_inspector_test.exs
+++ b/test/thinktank/run_inspector_test.exs
@@ -120,6 +120,22 @@ defmodule Thinktank.RunInspectorTest do
     assert run.trace_summary_file == Path.join(output_dir, "trace/summary.json")
   end
 
+  test "show prefers a terminal trace summary status over a stale manifest status" do
+    output_dir = Path.join(unique_tmp_dir("thinktank-run-inspector-terminal-summary"), "run")
+    init_run(output_dir, "research/default")
+    RunStore.complete_run(output_dir, "failed")
+
+    update_json(Path.join(output_dir, "manifest.json"), fn manifest ->
+      manifest
+      |> Map.put("status", "running")
+      |> Map.delete("completed_at")
+    end)
+
+    assert {:ok, run} = RunInspector.show(output_dir)
+    assert run.status == "failed"
+    assert run.completed_at != nil
+  end
+
   test "list returns recent runs sorted by started_at descending" do
     first_dir = Path.join(unique_tmp_dir("thinktank-run-inspector-list-first"), "first")
     init_run(first_dir, "research/default")
@@ -154,6 +170,23 @@ defmodule Thinktank.RunInspectorTest do
     assert {:ok, run} = RunInspector.show(Path.join(output_dir, "manifest.json"))
     assert run.output_dir == Path.expand(output_dir)
     assert run.status == "complete"
+  end
+
+  test "show treats an existing bare relative directory name as a path target" do
+    run_id = "custom-output-#{System.unique_integer([:positive])}"
+    parent = Path.join(System.tmp_dir!(), "custom-parent-#{System.unique_integer([:positive])}")
+    File.rm_rf!(parent)
+    File.mkdir_p!(parent)
+    output_dir = Path.join(parent, run_id)
+
+    init_run(output_dir, "research/default")
+
+    File.cd!(parent, fn ->
+      assert {:ok, run} = RunInspector.show(run_id, log_dir: nil)
+      assert Path.basename(run.output_dir) == run_id
+      assert Path.basename(Path.dirname(run.output_dir)) == Path.basename(parent)
+      assert run.status == "running"
+    end)
   end
 
   test "show returns a typed error for a missing run target" do
@@ -196,6 +229,11 @@ defmodule Thinktank.RunInspectorTest do
 
     assert {:error, %{category: :run_status_invalid, message: "unknown run status: \"mystery\""}} =
              RunInspector.show(output_dir)
+  end
+
+  test "list returns a typed error when run discovery raises unexpectedly" do
+    assert {:error, %{category: :run_list_failed, message: "failed to discover runs"}} =
+             RunInspector.list(tmp_dir: :invalid)
   end
 
   test "show returns a typed error when multiple runs share the same id" do
@@ -245,5 +283,20 @@ defmodule Thinktank.RunInspectorTest do
               message: "timed out waiting for run to finish: " <> ^output_dir
             }} =
              RunInspector.wait(output_dir, poll_ms: 5, timeout_ms: 0)
+  end
+
+  test "wait returns immediately when the trace summary is already terminal" do
+    output_dir = Path.join(unique_tmp_dir("thinktank-run-inspector-terminal-wait"), "run")
+    init_run(output_dir, "research/default")
+    RunStore.complete_run(output_dir, "degraded")
+
+    update_json(Path.join(output_dir, "manifest.json"), fn manifest ->
+      manifest
+      |> Map.put("status", "running")
+      |> Map.delete("completed_at")
+    end)
+
+    assert {:ok, run} = RunInspector.wait(output_dir, poll_ms: 5, timeout_ms: 0)
+    assert run.status == "degraded"
   end
 end


### PR DESCRIPTION
## Summary
- Add `thinktank runs list|show|wait` for discovering and inspecting completed runs
- Resolve targets by path or run id, with structured JSON and human-readable output
- Tighten run-inspection error handling, docs, and regression coverage
- Record the review score for this branch in `.groom/review-scores.ndjson`

## Testing
- Local unit coverage added for run resolution, terminal-state handling, malformed artifacts, and CLI JSON/error contracts
- Formatting, linting, and the full repository gate passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added thinktank run inspection CLI: runs list, runs show <path-or-id>, and runs wait <path-or-id> with --json and canonical run states (running, complete, degraded, partial, failed).

* **Documentation**
  * README updated to document run inspection commands, output envelopes, sorting/defaults, and wait/exit semantics; raw event tailing noted as a fallback.

* **Tests**
  * Added comprehensive tests covering parsing, listing, showing, waiting, errors, resolution, and exit-code behavior.

* **Chores**
  * Backlog item marked done and two review-score records appended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->