### PR TITLE
feat(research): add structured findings contract

### DIFF
--- a/.groom/review-scores.ndjson
+++ b/.groom/review-scores.ndjson
@@ -14,3 +14,4 @@
 {"date":"2026-04-20","pr":null,"correctness":8,"depth":6,"simplicity":8,"craft":8,"verdict":"conditional","providers":["codex","gemini"]}
 {"date":"2026-04-22","pr":null,"correctness":8,"depth":8,"simplicity":7,"craft":8,"verdict":"ship","providers":["codex","thinktank","gemini"]}
 {"date":"2026-04-23","pr":295,"correctness":9,"depth":8,"simplicity":8,"craft":8,"verdict":"ship","providers":["subagents","thinktank","gemini"]}
+{"date":"2026-04-23","pr":null,"correctness":9,"depth":8,"simplicity":8,"craft":9,"verdict":"ship","providers":["codex","subagents"]}

--- a/.groom/review-scores.ndjson
+++ b/.groom/review-scores.ndjson
@@ -15,3 +15,4 @@
 {"date":"2026-04-22","pr":null,"correctness":8,"depth":8,"simplicity":7,"craft":8,"verdict":"ship","providers":["codex","thinktank","gemini"]}
 {"date":"2026-04-23","pr":295,"correctness":9,"depth":8,"simplicity":8,"craft":8,"verdict":"ship","providers":["subagents","thinktank","gemini"]}
 {"date":"2026-04-23","pr":null,"correctness":9,"depth":8,"simplicity":8,"craft":9,"verdict":"ship","providers":["codex","subagents"]}
+{"date":"2026-04-23","pr":296,"correctness":9,"depth":8,"simplicity":9,"craft":9,"verdict":"ship","providers":["codex","subagents","thinktank"]}

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Each run writes:
 - `prompts/*.md` — rendered prompts passed to Pi
 - `summary.md` — synthesizer output when enabled
 - `synthesis.md` for research benches
+- `research/findings.json` for research benches with a schema-driven structured findings contract
 - `review.md` for review benches
 - `review/context.json` and `review/plan.json` for review benches (canonical structured review contract)
 - `review/context.md` and `review/plan.md` for review benches (optional derivative orientation artifacts)
@@ -193,7 +194,8 @@ running, stderr emits newline-delimited JSON progress events that surface the
 current phase, the selected `output_dir`, and periodic heartbeats for long
 runs. The final envelope includes `usd_cost_total`, `usd_cost_by_model`, and
 `pricing_gaps`, and the human-readable text output shows the same cost line.
-It does not write a `report.json` artifact. For research benches, the
+It does not write a `report.json` artifact. For research benches, canonical
+structured findings live in `research/findings.json` and the human-readable
 synthesized document lives in `synthesis.md` when a synthesizer is enabled.
 If a run times out, is interrupted, or loses synthesis after useful work has
 already been captured, ThinkTank finalizes it as `partial` and writes a

--- a/backlog.d/done/008-enforce-command-plane-architecture-gates.md
+++ b/backlog.d/done/008-enforce-command-plane-architecture-gates.md
@@ -1,7 +1,7 @@
 # Enforce Command-Plane Architecture Gates
 
 Priority: medium
-Status: in-progress
+Status: done
 Estimate: L
 
 ## Goal

--- a/backlog.d/done/023-add-structured-research-findings-contract.md
+++ b/backlog.d/done/023-add-structured-research-findings-contract.md
@@ -1,7 +1,7 @@
 # Add Structured Research Findings Contract
 
 Priority: high
-Status: ready
+Status: done
 Estimate: M
 
 ## Goal
@@ -29,11 +29,16 @@ Research benches become more useful to both humans and downstream agents because
 - `README.md`
 
 ## Oracle
-- [ ] `research/default` writes a canonical structured findings artifact in addition to `synthesis.md`
-- [ ] The structured artifact contains at least: `thesis`, `findings[]`, `evidence[]`, `open_questions[]`, and `confidence`
-- [ ] A synthesis failure or partial run produces an explicit typed status for the structured artifact instead of silently omitting it
-- [ ] `README.md` documents the structured research artifact and its role relative to raw outputs
-- [ ] Automated coverage proves successful structured synthesis, invalid-structure fallback, and partial-run behavior
+- [x] `research/default` writes a canonical structured findings artifact in addition to `synthesis.md`
+- [x] The structured artifact contains at least: `thesis`, `findings[]`, `evidence[]`, `open_questions[]`, and `confidence`
+- [x] A synthesis failure or partial run produces an explicit typed status for the structured artifact instead of silently omitting it
+- [x] `README.md` documents the structured research artifact and its role relative to raw outputs
+- [x] Automated coverage proves successful structured synthesis, invalid-structure fallback, and partial-run behavior
+
+## What Was Built
+- Research synthesis is now schema-first: `research-synth` returns structured JSON, `research/findings.json` is the canonical machine contract, and `synthesis.md` is rendered from validated findings.
+- Invalid JSON, invalid schema, synthesizer failures, and partial no-synthesis runs all surface typed `research_findings` statuses in the result envelope.
+- Result envelopes read findings only from manifest-recorded artifacts so reused output directories cannot leak stale files.
 
 ## Notes
 ThinkTank already records durable research artifacts, but today the synthesized result is primarily markdown. That is readable, but it limits reuse by downstream tools and makes “council of intelligence” style consumers depend on prose interpretation.

--- a/lib/thinktank/artifact_layout.ex
+++ b/lib/thinktank/artifact_layout.ex
@@ -9,6 +9,7 @@ defmodule Thinktank.ArtifactLayout do
   @summary_file "summary.md"
   @review_file "review.md"
   @synthesis_file "synthesis.md"
+  @research_findings_file "research/findings.json"
   @review_context_json_file "review/context.json"
   @review_context_text_file "review/context.md"
   @review_plan_json_file "review/plan.json"
@@ -44,6 +45,9 @@ defmodule Thinktank.ArtifactLayout do
 
   @spec review_planner_file() :: String.t()
   def review_planner_file, do: @review_planner_file
+
+  @spec research_findings_file() :: String.t()
+  def research_findings_file, do: @research_findings_file
 
   @spec scratchpads_dir() :: String.t()
   def scratchpads_dir, do: @scratchpads_dir

--- a/lib/thinktank/bench_spec.ex
+++ b/lib/thinktank/bench_spec.ex
@@ -8,6 +8,7 @@ defmodule Thinktank.BenchSpec do
     :id,
     :description,
     kind: :default,
+    structured_findings: false,
     agents: [],
     planner: nil,
     synthesizer: nil,
@@ -21,6 +22,7 @@ defmodule Thinktank.BenchSpec do
           id: String.t(),
           description: String.t(),
           kind: kind(),
+          structured_findings: boolean(),
           agents: [String.t()],
           planner: String.t() | nil,
           synthesizer: String.t() | nil,
@@ -32,6 +34,7 @@ defmodule Thinktank.BenchSpec do
   def from_pair(id, %{} = raw) when is_binary(id) do
     with {:ok, description} <- require_string(raw, "description"),
          {:ok, kind} <- parse_kind(raw["kind"]),
+         {:ok, structured_findings} <- parse_boolean(raw["structured_findings"], false),
          {:ok, agents} <- require_agent_names(raw["agents"]),
          {:ok, planner} <- optional_string(raw["planner"]),
          {:ok, synthesizer} <- optional_string(raw["synthesizer"]),
@@ -42,6 +45,7 @@ defmodule Thinktank.BenchSpec do
          id: id,
          description: description,
          kind: kind,
+         structured_findings: structured_findings,
          agents: agents,
          planner: planner,
          synthesizer: synthesizer,
@@ -99,6 +103,12 @@ defmodule Thinktank.BenchSpec do
   end
 
   defp parse_concurrency(_), do: {:error, "bench concurrency must be a positive integer"}
+
+  defp parse_boolean(nil, default), do: {:ok, default}
+  defp parse_boolean(value, _default) when is_boolean(value), do: {:ok, value}
+
+  defp parse_boolean(_value, _default),
+    do: {:error, "bench structured_findings must be a boolean"}
 
   defp present_string(value, error) when is_binary(value) do
     trimmed = String.trim(value)

--- a/lib/thinktank/builtin.ex
+++ b/lib/thinktank/builtin.ex
@@ -30,6 +30,7 @@ defmodule Thinktank.Builtin do
           "kind" => "research",
           "description" =>
             "Launch a fixed research bench of Pi agents and optionally synthesize their findings.",
+          "structured_findings" => true,
           "agents" => ["systems", "verification", "ml", "dx"],
           "synthesizer" => "research-synth",
           "concurrency" => 4

--- a/lib/thinktank/cli.ex
+++ b/lib/thinktank/cli.ex
@@ -75,6 +75,7 @@ defmodule Thinktank.CLI do
         id: bench.id,
         description: bench.description,
         kind: bench.kind,
+        structured_findings: bench.structured_findings,
         agents: agents_payload,
         planner: bench.planner,
         synthesizer: bench.synthesizer,

--- a/lib/thinktank/cli/render.ex
+++ b/lib/thinktank/cli/render.ex
@@ -112,6 +112,7 @@ defmodule Thinktank.CLI.Render do
     Bench: #{payload.id}
     Description: #{payload.description}
     Kind: #{payload.kind}
+    Structured Findings: #{payload.structured_findings}
     Planner: #{payload.planner || "none"}
     Synthesizer: #{payload.synthesizer || "none"}
     Concurrency: #{payload.concurrency || "none"}

--- a/lib/thinktank/engine/runtime.ex
+++ b/lib/thinktank/engine/runtime.ex
@@ -133,6 +133,7 @@ defmodule Thinktank.Engine.Runtime do
 
   alias Thinktank.Engine.Preparation
   alias Thinktank.Executor.Agentic
+  alias Thinktank.Research.Findings
 
   @type terminal_attrs :: map()
 
@@ -233,6 +234,7 @@ defmodule Thinktank.Engine.Runtime do
       )
 
     status = derive_status(results, synthesis)
+    maybe_write_partial_research_findings(output_dir, bench, status, synthesis)
 
     terminal_attrs = %{
       "bench" => bench.id,
@@ -319,15 +321,61 @@ defmodule Thinktank.Engine.Runtime do
           runner: opts[:runner]
         )
 
-      record_result(output_dir, result)
-
-      if result.status == :ok do
-        write_summary_artifacts(output_dir, bench, result.output)
-      end
-
-      result
+      handled_result = handle_synthesis_result(output_dir, bench, result)
+      record_result(output_dir, handled_result)
+      handled_result
     end
   end
+
+  defp handle_synthesis_result(output_dir, %BenchSpec{kind: :research} = bench, result) do
+    case result.status do
+      :ok ->
+        findings = Findings.from_synthesis_output(result.output)
+        write_research_findings(output_dir, findings)
+
+        if Findings.complete?(findings) do
+          write_summary_artifacts(output_dir, bench, Findings.to_markdown(findings))
+          result
+        else
+          %{result | status: :error, error: Findings.error(findings)}
+        end
+
+      :error ->
+        write_research_findings(output_dir, Findings.synthesis_failed(result.error))
+        result
+    end
+  end
+
+  defp handle_synthesis_result(output_dir, bench, result) do
+    if result.status == :ok do
+      write_summary_artifacts(output_dir, bench, result.output)
+    end
+
+    result
+  end
+
+  defp write_research_findings(output_dir, findings) do
+    RunStore.write_json_artifact(
+      output_dir,
+      "research-findings",
+      ArtifactLayout.research_findings_file(),
+      findings
+    )
+  end
+
+  defp maybe_write_partial_research_findings(
+         output_dir,
+         %BenchSpec{kind: :research} = bench,
+         "partial",
+         nil
+       ) do
+    write_research_findings(
+      output_dir,
+      Findings.partial(%{"bench" => bench.id, "status" => "partial"})
+    )
+  end
+
+  defp maybe_write_partial_research_findings(_output_dir, _bench, _status, _synthesis), do: :ok
 
   defp write_summary_artifacts(output_dir, %BenchSpec{kind: kind}, content) do
     Enum.each(ArtifactLayout.summary_artifacts(kind), fn {name, file} ->

--- a/lib/thinktank/engine/runtime.ex
+++ b/lib/thinktank/engine/runtime.ex
@@ -143,6 +143,7 @@ defmodule Thinktank.Engine.Runtime do
   def run(bench, agents, planner, contract, config, opts, synthesizer) do
     output_dir = contract.artifact_dir
     phase = Preparation.preparation_phase(bench, planner)
+    clear_stale_research_findings(output_dir, bench)
 
     Progress.emit(opts, "prepare_started", %{
       phase: phase,
@@ -177,6 +178,21 @@ defmodule Thinktank.Engine.Runtime do
         {:error, error, output_dir, "failed", terminal_attrs}
     end
   end
+
+  defp clear_stale_research_findings(
+         output_dir,
+         %BenchSpec{kind: :research, structured_findings: true}
+       ) do
+    path = Path.join(output_dir, ArtifactLayout.research_findings_file())
+
+    case File.rm(path) do
+      :ok -> :ok
+      {:error, :enoent} -> :ok
+      {:error, reason} -> raise File.Error, reason: reason, action: "remove", path: path
+    end
+  end
+
+  defp clear_stale_research_findings(_output_dir, _bench), do: :ok
 
   defp execute_bench(
          planned_agents,
@@ -327,7 +343,11 @@ defmodule Thinktank.Engine.Runtime do
     end
   end
 
-  defp handle_synthesis_result(output_dir, %BenchSpec{kind: :research} = bench, result) do
+  defp handle_synthesis_result(
+         output_dir,
+         %BenchSpec{kind: :research, structured_findings: true} = bench,
+         result
+       ) do
     case result.status do
       :ok ->
         findings = Findings.from_synthesis_output(result.output)
@@ -365,7 +385,7 @@ defmodule Thinktank.Engine.Runtime do
 
   defp maybe_write_partial_research_findings(
          output_dir,
-         %BenchSpec{kind: :research} = bench,
+         %BenchSpec{kind: :research, structured_findings: true} = bench,
          "partial",
          nil
        ) do

--- a/lib/thinktank/prompts/synthesis.ex
+++ b/lib/thinktank/prompts/synthesis.ex
@@ -1,9 +1,12 @@
 defmodule Thinktank.Prompts.Synthesis do
   @moduledoc false
 
+  alias Thinktank.Research.Findings
+
   @research_system """
-  You synthesize multiple research agent reports into one concise document.
+  You synthesize multiple research agent reports into one structured findings contract.
   Preserve disagreements. Do not invent consensus. Favor grounded recommendations over rhetoric.
+  Return valid JSON only. Do not wrap the JSON in Markdown fences.
   """
 
   @review_system """
@@ -18,7 +21,7 @@ defmodule Thinktank.Prompts.Synthesis do
   to fill space. Write a clear human review, not structured JSON.
   """
 
-  @research_task """
+  @research_task_prefix """
   Original task:
   {{input_text}}
 
@@ -57,6 +60,15 @@ defmodule Thinktank.Prompts.Synthesis do
 
   def research_system, do: @research_system
   def review_system, do: @review_system
-  def research_task, do: @research_task
+
+  def research_task do
+    """
+    #{@research_task_prefix}
+
+    Return JSON only with this shape:
+    #{Findings.schema_prompt()}
+    """
+  end
+
   def review_task, do: @review_task
 end

--- a/lib/thinktank/research/findings.ex
+++ b/lib/thinktank/research/findings.ex
@@ -131,22 +131,11 @@ defmodule Thinktank.Research.Findings do
 
   defp required_list(payload, key, normalize_entry) do
     case payload[key] do
-      value when is_list(value) -> collect_list(value, key, normalize_entry)
-      _ -> missing_or_invalid(key)
-    end
-  end
+      values when is_list(values) ->
+        normalize_list(values, normalize_entry, missing_or_invalid(key))
 
-  defp collect_list(values, key, normalize_entry) do
-    values
-    |> Enum.reduce_while({:ok, []}, fn value, {:ok, acc} ->
-      case normalize_entry.(value) do
-        {:ok, normalized} -> {:cont, {:ok, [normalized | acc]}}
-        :error -> {:halt, missing_or_invalid(key)}
-      end
-    end)
-    |> case do
-      {:ok, normalized} -> {:ok, Enum.reverse(normalized)}
-      error -> error
+      _ ->
+        missing_or_invalid(key)
     end
   end
 
@@ -157,7 +146,7 @@ defmodule Thinktank.Research.Findings do
   defp finding(%{} = finding) do
     with {:ok, claim} <- string_field(finding, "claim"),
          {:ok, evidence} <- string_list_field(finding, "evidence"),
-         {:ok, confidence} <- optional_confidence(finding, "confidence") do
+         {:ok, confidence} <- required_finding_confidence(finding, "confidence") do
       {:ok, %{"claim" => claim, "evidence" => evidence, "confidence" => confidence}}
     end
   end
@@ -185,31 +174,31 @@ defmodule Thinktank.Research.Findings do
 
   defp string_list_field(payload, key) do
     case payload[key] do
-      values when is_list(values) ->
-        collect_string_list(values)
-
-      _ ->
-        :error
+      values when is_list(values) -> normalize_list(values, &present_binary_string/1, :error)
+      _ -> :error
     end
   end
 
-  defp collect_string_list(values) do
+  defp normalize_list(values, normalize_entry, invalid_result) do
     values
     |> Enum.reduce_while({:ok, []}, fn
-      value, {:ok, acc} when is_binary(value) ->
-        case present_string(value) do
+      value, {:ok, acc} ->
+        case normalize_entry.(value) do
           {:ok, normalized} -> {:cont, {:ok, [normalized | acc]}}
-          :error -> {:halt, :error}
+          :error -> {:halt, invalid_result}
         end
 
       _value, _acc ->
-        {:halt, :error}
+        {:halt, invalid_result}
     end)
     |> case do
       {:ok, normalized} -> {:ok, Enum.reverse(normalized)}
-      :error -> :error
+      error -> error
     end
   end
+
+  defp present_binary_string(value) when is_binary(value), do: present_string(value)
+  defp present_binary_string(_value), do: :error
 
   defp present_string(value) do
     value = String.trim(value)
@@ -223,7 +212,12 @@ defmodule Thinktank.Research.Findings do
     end
   end
 
-  defp optional_confidence(payload, key), do: {:ok, normalize_confidence(payload[key])}
+  defp required_finding_confidence(payload, key) do
+    case normalize_confidence(payload[key]) do
+      confidence when confidence in ~w(high medium low) -> {:ok, confidence}
+      _ -> :error
+    end
+  end
 
   defp normalize_confidence(value) when is_binary(value) do
     value = value |> String.downcase() |> String.trim()

--- a/lib/thinktank/research/findings.ex
+++ b/lib/thinktank/research/findings.ex
@@ -1,0 +1,305 @@
+defmodule Thinktank.Research.Findings do
+  @moduledoc """
+  Structured research findings contract.
+  """
+
+  @schema_version 1
+  @confidence_levels ~w(high medium low unknown)
+
+  @spec schema_prompt() :: String.t()
+  def schema_prompt do
+    """
+    {
+      "thesis": "one-sentence synthesis of the strongest conclusion",
+      "findings": [
+        {
+          "claim": "specific finding or recommendation",
+          "evidence": ["file, command, source, or agent-output reference"],
+          "confidence": "high|medium|low"
+        }
+      ],
+      "evidence": [
+        {
+          "source": "file, command, source, or agent name",
+          "summary": "what this evidence supports"
+        }
+      ],
+      "open_questions": ["question that remains unresolved"],
+      "confidence": "high|medium|low"
+    }
+    """
+    |> String.trim()
+  end
+
+  @spec from_synthesis_output(String.t()) :: map()
+  def from_synthesis_output(output) when is_binary(output) do
+    case Jason.decode(output) do
+      {:ok, %{} = payload} ->
+        from_payload(payload, output)
+
+      {:ok, _other} ->
+        invalid("invalid_shape", "research findings synthesis must return a JSON object", output)
+
+      {:error, error} ->
+        invalid(
+          "invalid_json",
+          "research findings synthesis returned invalid JSON: #{Exception.message(error)}",
+          output
+        )
+    end
+  end
+
+  @spec complete?(map()) :: boolean()
+  def complete?(%{"status" => "complete"}), do: true
+  def complete?(_findings), do: false
+
+  @spec error(map()) :: map() | nil
+  def error(%{"error" => error}), do: error
+  def error(_findings), do: nil
+
+  @spec synthesis_failed(map() | nil) :: map()
+  def synthesis_failed(error) do
+    unavailable("synthesis_failed", "research synthesis failed before findings were available", %{
+      "error" => normalize(error)
+    })
+  end
+
+  @spec partial(map()) :: map()
+  def partial(details \\ %{}) do
+    base("partial", %{
+      "category" => "partial_run",
+      "message" => "research findings are unavailable because the run completed as partial",
+      "details" => normalize(details)
+    })
+  end
+
+  @spec to_markdown(map()) :: String.t()
+  def to_markdown(%{"status" => "complete"} = findings) do
+    """
+    # Research Synthesis
+
+    #{findings["thesis"]}
+
+    ## Findings
+
+    #{render_findings(findings["findings"])}
+
+    ## Evidence
+
+    #{render_evidence(findings["evidence"])}
+
+    ## Open Questions
+
+    #{render_open_questions(findings["open_questions"])}
+
+    Confidence: #{findings["confidence"]}
+    """
+    |> String.trim()
+  end
+
+  defp from_payload(payload, raw_output) do
+    with {:ok, thesis} <- required_string(payload, "thesis"),
+         {:ok, findings} <- required_list(payload, "findings", &finding/1),
+         {:ok, evidence} <- required_list(payload, "evidence", &evidence/1),
+         {:ok, open_questions} <- required_list(payload, "open_questions", &open_question/1),
+         {:ok, confidence} <- required_confidence(payload, "confidence") do
+      %{
+        "schema_version" => @schema_version,
+        "status" => "complete",
+        "thesis" => thesis,
+        "findings" => findings,
+        "evidence" => evidence,
+        "open_questions" => open_questions,
+        "confidence" => confidence,
+        "error" => nil
+      }
+    else
+      {:error, category, message} -> invalid(category, message, raw_output)
+    end
+  end
+
+  defp required_string(payload, key) do
+    case payload[key] do
+      value when is_binary(value) ->
+        value = String.trim(value)
+        if value == "", do: missing_or_invalid(key), else: {:ok, value}
+
+      _ ->
+        missing_or_invalid(key)
+    end
+  end
+
+  defp required_list(payload, key, normalize_entry) do
+    case payload[key] do
+      value when is_list(value) -> collect_list(value, key, normalize_entry)
+      _ -> missing_or_invalid(key)
+    end
+  end
+
+  defp collect_list(values, key, normalize_entry) do
+    values
+    |> Enum.reduce_while({:ok, []}, fn value, {:ok, acc} ->
+      case normalize_entry.(value) do
+        {:ok, normalized} -> {:cont, {:ok, [normalized | acc]}}
+        :error -> {:halt, missing_or_invalid(key)}
+      end
+    end)
+    |> case do
+      {:ok, normalized} -> {:ok, Enum.reverse(normalized)}
+      error -> error
+    end
+  end
+
+  defp missing_or_invalid(key) do
+    {:error, "invalid_shape", "research findings field #{inspect(key)} is missing or invalid"}
+  end
+
+  defp finding(%{} = finding) do
+    with {:ok, claim} <- string_field(finding, "claim"),
+         {:ok, evidence} <- string_list_field(finding, "evidence"),
+         {:ok, confidence} <- optional_confidence(finding, "confidence") do
+      {:ok, %{"claim" => claim, "evidence" => evidence, "confidence" => confidence}}
+    end
+  end
+
+  defp finding(_value), do: :error
+
+  defp evidence(%{} = evidence) do
+    with {:ok, source} <- string_field(evidence, "source"),
+         {:ok, summary} <- string_field(evidence, "summary") do
+      {:ok, %{"source" => source, "summary" => summary}}
+    end
+  end
+
+  defp evidence(_value), do: :error
+
+  defp open_question(value) when is_binary(value), do: present_string(value)
+  defp open_question(_value), do: :error
+
+  defp string_field(payload, key) do
+    case payload[key] do
+      value when is_binary(value) -> present_string(value)
+      _ -> :error
+    end
+  end
+
+  defp string_list_field(payload, key) do
+    case payload[key] do
+      values when is_list(values) ->
+        collect_string_list(values)
+
+      _ ->
+        :error
+    end
+  end
+
+  defp collect_string_list(values) do
+    values
+    |> Enum.reduce_while({:ok, []}, fn
+      value, {:ok, acc} when is_binary(value) ->
+        case present_string(value) do
+          {:ok, normalized} -> {:cont, {:ok, [normalized | acc]}}
+          :error -> {:halt, :error}
+        end
+
+      _value, _acc ->
+        {:halt, :error}
+    end)
+    |> case do
+      {:ok, normalized} -> {:ok, Enum.reverse(normalized)}
+      :error -> :error
+    end
+  end
+
+  defp present_string(value) do
+    value = String.trim(value)
+    if value == "", do: :error, else: {:ok, value}
+  end
+
+  defp required_confidence(payload, key) do
+    case normalize_confidence(payload[key]) do
+      "unknown" -> missing_or_invalid(key)
+      confidence -> {:ok, confidence}
+    end
+  end
+
+  defp optional_confidence(payload, key), do: {:ok, normalize_confidence(payload[key])}
+
+  defp normalize_confidence(value) when is_binary(value) do
+    value = value |> String.downcase() |> String.trim()
+    if value in @confidence_levels, do: value, else: "unknown"
+  end
+
+  defp normalize_confidence(_value), do: "unknown"
+
+  defp invalid(category, message, raw_output) do
+    base("invalid", %{
+      "category" => category,
+      "message" => message,
+      "raw_output_sha256" => sha256(raw_output)
+    })
+  end
+
+  defp unavailable(category, message, details) do
+    base("unavailable", %{
+      "category" => category,
+      "message" => message,
+      "details" => normalize(details)
+    })
+  end
+
+  defp base(status, error) do
+    %{
+      "schema_version" => @schema_version,
+      "status" => status,
+      "thesis" => nil,
+      "findings" => [],
+      "evidence" => [],
+      "open_questions" => [],
+      "confidence" => "unknown",
+      "error" => error
+    }
+  end
+
+  defp render_findings([]), do: "_No findings were returned._"
+
+  defp render_findings(findings) do
+    Enum.map_join(findings, "\n", fn finding ->
+      evidence =
+        case finding["evidence"] do
+          [] -> ""
+          refs -> " Evidence: #{Enum.join(refs, "; ")}."
+        end
+
+      "- #{finding["claim"]} (confidence: #{finding["confidence"]}).#{evidence}"
+    end)
+  end
+
+  defp render_evidence([]), do: "_No evidence was returned._"
+
+  defp render_evidence(evidence) do
+    Enum.map_join(evidence, "\n", fn item ->
+      "- #{item["source"]}: #{item["summary"]}"
+    end)
+  end
+
+  defp render_open_questions([]), do: "_No open questions._"
+
+  defp render_open_questions(questions) do
+    Enum.map_join(questions, "\n", &"- #{&1}")
+  end
+
+  defp normalize(value) when is_map(value),
+    do: Map.new(value, fn {key, val} -> {to_string(key), normalize(val)} end)
+
+  defp normalize(value) when is_list(value), do: Enum.map(value, &normalize/1)
+  defp normalize(value) when is_binary(value) or is_number(value) or is_boolean(value), do: value
+  defp normalize(nil), do: nil
+  defp normalize(value) when is_atom(value), do: Atom.to_string(value)
+  defp normalize(value), do: inspect(value)
+
+  defp sha256(value) do
+    :crypto.hash(:sha256, value)
+    |> Base.encode16(case: :lower)
+  end
+end

--- a/lib/thinktank/run_store.ex
+++ b/lib/thinktank/run_store.ex
@@ -181,8 +181,6 @@ defmodule Thinktank.RunStore do
       Enum.each(ArtifactLayout.summary_artifacts(manifest["kind"]), fn {name, file} ->
         write_text_artifact(output_dir, name, file, content)
       end)
-    else
-      :ok
     end
   end
 
@@ -207,6 +205,8 @@ defmodule Thinktank.RunStore do
       usd_cost_total: manifest["usd_cost_total"],
       usd_cost_by_model: manifest["usd_cost_by_model"],
       pricing_gaps: manifest["pricing_gaps"],
+      research_findings:
+        read_json_artifact(artifact_named(artifacts, "research-findings"), output_dir),
       synthesis: read_synthesis(output_dir, artifacts)
     }
   end
@@ -237,6 +237,22 @@ defmodule Thinktank.RunStore do
   defp read_artifact(%{"file" => file}, output_dir) do
     path = Path.join(output_dir, file)
     if File.exists?(path), do: File.read!(path), else: nil
+  end
+
+  defp read_json_artifact(nil, _output_dir), do: nil
+
+  defp read_json_artifact(%{"file" => file}, output_dir) do
+    path = Path.join(output_dir, file)
+
+    with true <- File.exists?(path), {:ok, decoded} <- path |> File.read!() |> Jason.decode() do
+      decoded
+    else
+      _error -> nil
+    end
+  end
+
+  defp artifact_named(artifacts, name) do
+    Enum.find(artifacts, &(&1["name"] == name))
   end
 
   defp init_run_scratchpad(output_dir, contract, bench, started_at) do

--- a/test/support/fake_pi.ex
+++ b/test/support/fake_pi.ex
@@ -155,7 +155,15 @@ defmodule Thinktank.Test.FakePi do
         '"synthesis_brief":"Use grounded evidence.",' \\
         '"warnings":[]}'
       ;;
-      review-synth-*|research-synth-*)
+      research-synth-*)
+      printf '%s\n' \
+        '{"thesis":"Synthetic research thesis.",' \
+        '"findings":[{"claim":"Synthetic finding.","evidence":["fake-pi"],"confidence":"high"}],' \
+        '"evidence":[{"source":"fake-pi","summary":"Hermetic synthesis output."}],' \
+        '"open_questions":[],' \
+        '"confidence":"high"}'
+      ;;
+      review-synth-*)
       echo "Synthesized summary"
       ;;
       *)

--- a/test/thinktank/bench_spec_test.exs
+++ b/test/thinktank/bench_spec_test.exs
@@ -9,6 +9,7 @@ defmodule Thinktank.BenchSpecTest do
                "kind" => "review",
                "description" => "Review bench",
                "agents" => ["trace", "guard"],
+               "structured_findings" => true,
                "planner" => "marshal",
                "synthesizer" => "review-synth",
                "concurrency" => "2",
@@ -17,6 +18,7 @@ defmodule Thinktank.BenchSpecTest do
 
     assert bench.id == "review/default"
     assert bench.kind == :review
+    assert bench.structured_findings == true
     assert bench.agents == ["trace", "guard"]
     assert bench.planner == "marshal"
     assert bench.synthesizer == "review-synth"
@@ -32,7 +34,12 @@ defmodule Thinktank.BenchSpecTest do
           {%{"description" => "Review bench", "agents" => ["trace", 123]},
            "bench agents must be a non-empty list of agent names"},
           {%{"description" => "Review bench", "agents" => ["trace"], "default_task" => "   "},
-           "bench optional string fields must be strings"}
+           "bench optional string fields must be strings"},
+          {%{
+             "description" => "Review bench",
+             "agents" => ["trace"],
+             "structured_findings" => "yes"
+           }, "bench structured_findings must be a boolean"}
         ] do
       assert {:error, ^expected_error} = BenchSpec.from_pair("review/default", raw)
     end
@@ -46,6 +53,7 @@ defmodule Thinktank.BenchSpecTest do
              })
 
     assert bench.kind == :default
+    assert bench.structured_findings == false
     assert bench.planner == nil
     assert bench.synthesizer == nil
     assert bench.concurrency == nil

--- a/test/thinktank/cli_test.exs
+++ b/test/thinktank/cli_test.exs
@@ -766,6 +766,7 @@ defmodule Thinktank.CLITest do
 
     assert {:ok, decoded} = Jason.decode(String.trim(output))
     assert is_list(decoded["agents"])
+    assert is_boolean(decoded["structured_findings"])
 
     assert [_ | _] = decoded["agents"]
 
@@ -794,6 +795,7 @@ defmodule Thinktank.CLITest do
     assert {:ok, decoded} = Jason.decode(String.trim(output))
     assert decoded["id"] == "research/default"
     assert decoded["kind"] == "research"
+    assert decoded["structured_findings"] == true
     assert decoded["agents"] == ["systems", "verification", "ml", "dx"]
     assert decoded["planner"] == nil
     assert decoded["synthesizer"] == "research-synth"
@@ -811,6 +813,7 @@ defmodule Thinktank.CLITest do
     assert output =~ "Bench: research/default"
     assert output =~ "Description:"
     assert output =~ "Kind: research"
+    assert output =~ "Structured Findings: true"
     assert output =~ "Agents:"
     assert output =~ "- systems"
     assert output =~ "- verification"

--- a/test/thinktank/config_test.exs
+++ b/test/thinktank/config_test.exs
@@ -24,6 +24,8 @@ defmodule Thinktank.ConfigTest do
     assert Map.has_key?(config.agents, "trace")
     assert config.benches["research/quick"].kind == :research
     assert config.benches["research/default"].kind == :research
+    assert config.benches["research/quick"].structured_findings == false
+    assert config.benches["research/default"].structured_findings == true
     assert config.benches["review/default"].kind == :review
     assert config.benches["review/default"].planner == "marshal"
   end

--- a/test/thinktank/engine_test.exs
+++ b/test/thinktank/engine_test.exs
@@ -144,7 +144,180 @@ defmodule Thinktank.EngineTest do
     assert result.envelope.status == "partial"
     assert File.read!(Path.join(result.output_dir, "summary.md")) =~ "Partial Result"
     assert File.read!(Path.join(result.output_dir, "summary.md")) =~ "partial finding"
+    assert result.envelope.research_findings["status"] == "partial"
+    assert result.envelope.research_findings["error"]["category"] == "partial_run"
     assert File.exists?(Path.join(result.output_dir, "scratchpads/run.md"))
+  end
+
+  test "partial research runs overwrite stale unrecorded findings in reused output directories" do
+    cwd = unique_tmp_dir("thinktank-engine-partial-stale-findings")
+    output_dir = Path.join(cwd, "reused-run")
+    stale_findings_path = Path.join(output_dir, "research/findings.json")
+    File.mkdir_p!(Path.dirname(stale_findings_path))
+
+    File.write!(
+      stale_findings_path,
+      Jason.encode!(%{
+        status: "complete",
+        thesis: "stale",
+        findings: [],
+        evidence: [],
+        open_questions: [],
+        confidence: "high"
+      })
+    )
+
+    runner = fn _cmd, _args, _opts -> {"partial finding", :timeout} end
+
+    assert {:ok, result} =
+             Engine.run(
+               "research/default",
+               %{input_text: "Research this", agents: ["systems"], no_synthesis: true},
+               cwd: cwd,
+               output: output_dir,
+               runner: runner
+             )
+
+    assert result.envelope.status == "partial"
+    assert result.envelope.research_findings["status"] == "partial"
+    assert result.envelope.research_findings["error"]["category"] == "partial_run"
+  end
+
+  test "research synthesis writes structured findings alongside the prose synthesis" do
+    cwd = unique_tmp_dir("thinktank-engine-research-findings")
+
+    runner = fn _cmd, args, _opts ->
+      prompt = File.read!(prompt_path(args))
+
+      if String.contains?(prompt, "Raw agent report") do
+        {Jason.encode!(%{
+           thesis: "The repo already has a thin launcher boundary.",
+           findings: [
+             %{
+               claim: "Artifacts are recorded through RunStore.",
+               evidence: ["lib/thinktank/run_store.ex"],
+               confidence: "high"
+             }
+           ],
+           evidence: [
+             %{
+               source: "lib/thinktank/run_store.ex",
+               summary: "RunStore owns manifest artifact registration."
+             }
+           ],
+           open_questions: ["Should downstream tools read the new field directly?"],
+           confidence: "high"
+         }), 0}
+      else
+        {"Raw agent report", 0}
+      end
+    end
+
+    assert {:ok, result} =
+             Engine.run(
+               "research/default",
+               %{input_text: "Research this", agents: ["systems"]},
+               cwd: cwd,
+               runner: runner
+             )
+
+    findings_path = Path.join(result.output_dir, "research/findings.json")
+
+    assert result.envelope.status == "complete"
+
+    assert File.read!(Path.join(result.output_dir, "synthesis.md")) =~
+             "The repo already has a thin launcher boundary."
+
+    assert File.exists?(findings_path)
+    assert result.envelope.research_findings["status"] == "complete"
+
+    assert result.envelope.research_findings["thesis"] ==
+             "The repo already has a thin launcher boundary."
+
+    assert hd(result.envelope.research_findings["findings"])["claim"] =~ "Artifacts are recorded"
+
+    assert Enum.any?(
+             result.envelope.artifacts,
+             &(&1["name"] == "research-findings" and &1["file"] == "research/findings.json")
+           )
+  end
+
+  test "research findings record invalid structured synthesis without parsing markdown" do
+    cwd = unique_tmp_dir("thinktank-engine-research-findings-invalid")
+
+    runner = fn _cmd, args, _opts ->
+      prompt = File.read!(prompt_path(args))
+
+      if String.contains?(prompt, "Raw agent report") do
+        {"not json", 0}
+      else
+        {"Raw agent report", 0}
+      end
+    end
+
+    assert {:ok, result} =
+             Engine.run(
+               "research/default",
+               %{input_text: "Research this", agents: ["systems"]},
+               cwd: cwd,
+               runner: runner
+             )
+
+    assert result.envelope.status == "partial"
+    assert result.envelope.research_findings["status"] == "invalid"
+    assert result.envelope.research_findings["error"]["category"] == "invalid_json"
+  end
+
+  test "research findings record invalid schema without accepting partial JSON" do
+    cwd = unique_tmp_dir("thinktank-engine-research-findings-invalid-shape")
+
+    runner = fn _cmd, args, _opts ->
+      prompt = File.read!(prompt_path(args))
+
+      if String.contains?(prompt, "Raw agent report") do
+        {Jason.encode!(%{thesis: "Missing required lists.", confidence: "high"}), 0}
+      else
+        {"Raw agent report", 0}
+      end
+    end
+
+    assert {:ok, result} =
+             Engine.run(
+               "research/default",
+               %{input_text: "Research this", agents: ["systems"]},
+               cwd: cwd,
+               runner: runner
+             )
+
+    assert result.envelope.status == "partial"
+    assert result.envelope.research_findings["status"] == "invalid"
+    assert result.envelope.research_findings["error"]["category"] == "invalid_shape"
+  end
+
+  test "research findings record synthesizer process failures" do
+    cwd = unique_tmp_dir("thinktank-engine-research-findings-synth-fail")
+
+    runner = fn _cmd, args, _opts ->
+      prompt = File.read!(prompt_path(args))
+
+      if String.contains?(prompt, "Raw agent report") do
+        {"synth crashed", 1}
+      else
+        {"Raw agent report", 0}
+      end
+    end
+
+    assert {:ok, result} =
+             Engine.run(
+               "research/default",
+               %{input_text: "Research this", agents: ["systems"]},
+               cwd: cwd,
+               runner: runner
+             )
+
+    assert result.envelope.status == "partial"
+    assert result.envelope.research_findings["status"] == "unavailable"
+    assert result.envelope.research_findings["error"]["category"] == "synthesis_failed"
   end
 
   test "supports overriding a bench agent subset" do
@@ -678,10 +851,16 @@ defmodule Thinktank.EngineTest do
     runner = fn _cmd, args, _opts ->
       prompt = File.read!(prompt_path(args))
 
-      if String.contains?(prompt, "Agent outputs:") do
-        {"Synthesized summary", 0}
+      if String.contains?(prompt, "Progress agent report") do
+        {Jason.encode!(%{
+           thesis: "Progress synthesis completed.",
+           findings: [],
+           evidence: [],
+           open_questions: [],
+           confidence: "high"
+         }), 0}
       else
-        {"ok", 0}
+        {"Progress agent report", 0}
       end
     end
 

--- a/test/thinktank/engine_test.exs
+++ b/test/thinktank/engine_test.exs
@@ -183,6 +183,39 @@ defmodule Thinktank.EngineTest do
     assert result.envelope.research_findings["error"]["category"] == "partial_run"
   end
 
+  test "failed research runs clear stale findings files in reused output directories" do
+    cwd = unique_tmp_dir("thinktank-engine-failed-stale-findings")
+    output_dir = Path.join(cwd, "reused-run")
+    stale_findings_path = Path.join(output_dir, "research/findings.json")
+    File.mkdir_p!(Path.dirname(stale_findings_path))
+
+    File.write!(
+      stale_findings_path,
+      Jason.encode!(%{
+        status: "complete",
+        thesis: "stale",
+        findings: [],
+        evidence: [],
+        open_questions: [],
+        confidence: "high"
+      })
+    )
+
+    runner = fn _cmd, _args, _opts -> {"simulated failure", 1} end
+
+    assert {:error, %Error{code: :no_successful_agents}, ^output_dir} =
+             Engine.run(
+               "research/default",
+               %{input_text: "Research this", agents: ["systems"], no_synthesis: true},
+               cwd: cwd,
+               output: output_dir,
+               runner: runner
+             )
+
+    refute File.exists?(stale_findings_path)
+    assert Thinktank.RunStore.result_envelope(output_dir).research_findings == nil
+  end
+
   test "research synthesis writes structured findings alongside the prose synthesis" do
     cwd = unique_tmp_dir("thinktank-engine-research-findings")
 
@@ -403,6 +436,145 @@ defmodule Thinktank.EngineTest do
     assert File.exists?(Path.join(result.output_dir, "review.md"))
     assert File.read!(Path.join(result.output_dir, "review.md")) =~ "Synthesized review"
     refute File.exists?(Path.join(result.output_dir, "synthesis.md"))
+  end
+
+  test "custom research benches keep prose synthesis unless structured findings are enabled" do
+    cwd = unique_tmp_dir("thinktank-engine-custom-research")
+    output_dir = Path.join(cwd, "reused-run")
+    config_path = Path.join([cwd, ".thinktank", "config.yml"])
+    File.mkdir_p!(Path.dirname(config_path))
+
+    File.write!(
+      config_path,
+      """
+      benches:
+        demo/custom-research:
+          kind: research
+          description: Demo custom research bench
+          agents:
+            - systems
+          synthesizer: review-synth
+          default_task: Research the current change and summarize the result.
+      """
+    )
+
+    init_git_repo_with_commit!(cwd)
+    stale_findings_path = Path.join(output_dir, "research/findings.json")
+    File.mkdir_p!(Path.dirname(stale_findings_path))
+
+    stale_findings =
+      Jason.encode!(%{
+        status: "complete",
+        thesis: "stale",
+        findings: [],
+        evidence: [],
+        open_questions: [],
+        confidence: "high"
+      })
+
+    File.write!(stale_findings_path, stale_findings)
+
+    runner = fn _cmd, args, _opts ->
+      prompt = File.read!(prompt_path(args))
+
+      if String.contains?(prompt, "Agent outputs:") do
+        {"Synthesized research\n\n" <> prompt, 0}
+      else
+        {"Raw agent report\n\n" <> prompt, 0}
+      end
+    end
+
+    assert {:ok, result} =
+             Engine.run(
+               "demo/custom-research",
+               %{},
+               cwd: cwd,
+               output: output_dir,
+               trust_repo_config: true,
+               runner: runner
+             )
+
+    assert result.envelope.status == "complete"
+    assert result.envelope.research_findings == nil
+    refute Enum.any?(result.envelope.artifacts, &(&1["name"] == "research-findings"))
+    assert File.exists?(Path.join(result.output_dir, "summary.md"))
+    assert File.exists?(Path.join(result.output_dir, "synthesis.md"))
+    assert File.read!(Path.join(result.output_dir, "synthesis.md")) =~ "Synthesized research"
+    assert File.read!(stale_findings_path) == stale_findings
+  end
+
+  test "custom research benches can opt into structured findings" do
+    cwd = unique_tmp_dir("thinktank-engine-custom-structured-research")
+    output_dir = Path.join(cwd, "reused-run")
+    config_path = Path.join([cwd, ".thinktank", "config.yml"])
+    File.mkdir_p!(Path.dirname(config_path))
+
+    File.write!(
+      config_path,
+      """
+      benches:
+        demo/custom-structured-research:
+          kind: research
+          structured_findings: true
+          description: Demo custom research bench with structured findings
+          agents:
+            - systems
+          synthesizer: research-synth
+          default_task: Research the current change and summarize the result.
+      """
+    )
+
+    init_git_repo_with_commit!(cwd)
+    stale_findings_path = Path.join(output_dir, "research/findings.json")
+    File.mkdir_p!(Path.dirname(stale_findings_path))
+
+    File.write!(
+      stale_findings_path,
+      Jason.encode!(%{"status" => "complete", "thesis" => "stale"})
+    )
+
+    runner = fn _cmd, args, _opts ->
+      prompt = File.read!(prompt_path(args))
+
+      if String.contains?(prompt, "Raw agent report") do
+        {Jason.encode!(%{
+           thesis: "Structured findings stay opt-in.",
+           findings: [
+             %{
+               claim: "Custom benches can keep prose or opt into JSON.",
+               evidence: ["lib/thinktank/bench_spec.ex"],
+               confidence: "high"
+             }
+           ],
+           evidence: [
+             %{
+               source: "lib/thinktank/bench_spec.ex",
+               summary: "BenchSpec now carries the structured findings flag."
+             }
+           ],
+           open_questions: [],
+           confidence: "high"
+         }), 0}
+      else
+        {"Raw agent report", 0}
+      end
+    end
+
+    assert {:ok, result} =
+             Engine.run(
+               "demo/custom-structured-research",
+               %{},
+               cwd: cwd,
+               output: output_dir,
+               trust_repo_config: true,
+               runner: runner
+             )
+
+    assert result.envelope.status == "complete"
+    assert result.envelope.research_findings["status"] == "complete"
+    assert result.envelope.research_findings["thesis"] == "Structured findings stay opt-in."
+    assert File.read!(stale_findings_path) =~ "Structured findings stay opt-in."
+    assert File.exists?(Path.join(result.output_dir, "synthesis.md"))
   end
 
   test "review runs write context and plan artifacts and focus the reviewer subset" do

--- a/test/thinktank/integration/agent_contract_test.exs
+++ b/test/thinktank/integration/agent_contract_test.exs
@@ -135,6 +135,7 @@ defmodule Thinktank.Integration.AgentContractTest do
                    "error",
                    "output_dir",
                    "pricing_gaps",
+                   "research_findings",
                    "started_at",
                    "status",
                    "synthesis",
@@ -152,6 +153,7 @@ defmodule Thinktank.Integration.AgentContractTest do
           assert payload["usd_cost_total"] == 0.0
           assert payload["usd_cost_by_model"] == %{}
           assert payload["pricing_gaps"] == []
+          assert payload["research_findings"] == nil
           assert File.exists?(Path.join(payload["output_dir"], "contract.json"))
         end)
       end)

--- a/test/thinktank/prompts/synthesis_test.exs
+++ b/test/thinktank/prompts/synthesis_test.exs
@@ -2,6 +2,7 @@ defmodule Thinktank.Prompts.SynthesisTest do
   use ExUnit.Case, async: true
 
   alias Thinktank.Prompts.Synthesis
+  alias Thinktank.Research.Findings
 
   test "research_task/0 contains required placeholders" do
     task = Synthesis.research_task()
@@ -9,6 +10,9 @@ defmodule Thinktank.Prompts.SynthesisTest do
     for placeholder <- ~w({{input_text}} {{workspace_root}} {{paths_hint}} {{agent_outputs}}) do
       assert task =~ placeholder, "research synthesis task missing #{placeholder}"
     end
+
+    assert task =~ "JSON"
+    assert task =~ Findings.schema_prompt()
   end
 
   test "review_task/0 contains required placeholders" do

--- a/test/thinktank/research/findings_test.exs
+++ b/test/thinktank/research/findings_test.exs
@@ -1,0 +1,153 @@
+defmodule Thinktank.Research.FindingsTest do
+  use ExUnit.Case, async: true
+
+  alias Thinktank.Research.Findings
+
+  test "parses a valid payload and normalizes confidences" do
+    output =
+      Jason.encode!(%{
+        thesis: "  The launcher boundary is already thin.  ",
+        findings: [
+          %{
+            claim: "  Artifacts are persisted through RunStore.  ",
+            evidence: [" lib/thinktank/run_store.ex "],
+            confidence: " HIGH "
+          }
+        ],
+        evidence: [
+          %{
+            source: " lib/thinktank/run_store.ex ",
+            summary: " RunStore records findings artifacts. "
+          }
+        ],
+        open_questions: [" Should downstream tools consume findings directly? "],
+        confidence: " Medium "
+      })
+
+    findings = Findings.from_synthesis_output(output)
+
+    assert findings["status"] == "complete"
+    assert findings["thesis"] == "The launcher boundary is already thin."
+    assert findings["confidence"] == "medium"
+    assert hd(findings["findings"])["claim"] == "Artifacts are persisted through RunStore."
+    assert hd(findings["findings"])["evidence"] == ["lib/thinktank/run_store.ex"]
+    assert hd(findings["findings"])["confidence"] == "high"
+  end
+
+  test "returns invalid artifact for invalid json" do
+    findings = Findings.from_synthesis_output("not json")
+
+    assert findings["status"] == "invalid"
+    assert findings["error"]["category"] == "invalid_json"
+  end
+
+  test "returns invalid artifact for invalid shape" do
+    output =
+      Jason.encode!(%{
+        thesis: "Missing required list fields.",
+        confidence: "high"
+      })
+
+    findings = Findings.from_synthesis_output(output)
+
+    assert findings["status"] == "invalid"
+    assert findings["error"]["category"] == "invalid_shape"
+  end
+
+  test "returns invalid artifact when a finding is missing confidence" do
+    output =
+      Jason.encode!(%{
+        thesis: "Missing per-finding confidence should fail.",
+        findings: [
+          %{
+            claim: "A claim",
+            evidence: ["source"]
+          }
+        ],
+        evidence: [
+          %{
+            source: "source",
+            summary: "summary"
+          }
+        ],
+        open_questions: [],
+        confidence: "high"
+      })
+
+    findings = Findings.from_synthesis_output(output)
+
+    assert findings["status"] == "invalid"
+    assert findings["error"]["category"] == "invalid_shape"
+  end
+
+  test "returns invalid artifact when a finding has invalid confidence" do
+    output =
+      Jason.encode!(%{
+        thesis: "Invalid per-finding confidence should fail.",
+        findings: [
+          %{
+            claim: "A claim",
+            evidence: ["source"],
+            confidence: "certainly"
+          }
+        ],
+        evidence: [
+          %{
+            source: "source",
+            summary: "summary"
+          }
+        ],
+        open_questions: [],
+        confidence: "high"
+      })
+
+    findings = Findings.from_synthesis_output(output)
+
+    assert findings["status"] == "invalid"
+    assert findings["error"]["category"] == "invalid_shape"
+  end
+
+  test "renders markdown for complete findings" do
+    markdown =
+      Findings.to_markdown(%{
+        "status" => "complete",
+        "thesis" => "The launcher is thin.",
+        "findings" => [
+          %{
+            "claim" => "RunStore records artifacts.",
+            "evidence" => ["lib/thinktank/run_store.ex"],
+            "confidence" => "high"
+          }
+        ],
+        "evidence" => [
+          %{
+            "source" => "lib/thinktank/run_store.ex",
+            "summary" => "Artifact writes are centralized."
+          }
+        ],
+        "open_questions" => ["Should this flow expose stronger contracts?"],
+        "confidence" => "high"
+      })
+
+    assert markdown =~ "# Research Synthesis"
+    assert markdown =~ "RunStore records artifacts."
+    assert markdown =~ "Evidence: lib/thinktank/run_store.ex."
+    assert markdown =~ "Confidence: high"
+  end
+
+  test "renders empty sections with explicit placeholders" do
+    markdown =
+      Findings.to_markdown(%{
+        "status" => "complete",
+        "thesis" => "No findings yet.",
+        "findings" => [],
+        "evidence" => [],
+        "open_questions" => [],
+        "confidence" => "unknown"
+      })
+
+    assert markdown =~ "_No findings were returned._"
+    assert markdown =~ "_No evidence was returned._"
+    assert markdown =~ "_No open questions._"
+  end
+end

--- a/test/thinktank/run_store_test.exs
+++ b/test/thinktank/run_store_test.exs
@@ -104,6 +104,16 @@ defmodule Thinktank.RunStoreTest do
     RunStore.init_run(output_dir, contract, bench)
     RunStore.record_agent_result(output_dir, "systems", "hello", %{status: :ok})
     RunStore.write_text_artifact(output_dir, "synthesis", "synthesis.md", "Synthesized content")
+
+    RunStore.write_json_artifact(output_dir, "research-findings", "research/findings.json", %{
+      status: "complete",
+      thesis: "Structured result",
+      findings: [],
+      evidence: [],
+      open_questions: [],
+      confidence: "high"
+    })
+
     RunStore.write_text_artifact(output_dir, "summary", "summary.md", "Summary content")
     RunStore.complete_run(output_dir, "complete")
 
@@ -121,8 +131,54 @@ defmodule Thinktank.RunStoreTest do
     assert synth_artifact["content_type"] == "text/markdown"
     assert synth_artifact["type"] == "text"
 
+    findings_artifact = Enum.find(envelope.artifacts, &(&1["name"] == "research-findings"))
+    assert findings_artifact["content_type"] == "application/json"
+    assert envelope.research_findings["thesis"] == "Structured result"
+
     json_artifact = Enum.find(envelope.artifacts, &(&1["name"] == "contract"))
     assert json_artifact["content_type"] == "application/json"
+  end
+
+  test "result_envelope ignores unrecorded stale research findings files" do
+    output_dir = Path.join(unique_tmp_dir("thinktank-run-store-stale-findings"), "run")
+
+    contract = %RunContract{
+      bench_id: "research/default",
+      workspace_root: File.cwd!(),
+      input: %{input_text: "hello"},
+      artifact_dir: output_dir,
+      adapter_context: %{}
+    }
+
+    bench = %BenchSpec{id: "research/default", description: "Demo", agents: ["systems"]}
+
+    RunStore.init_run(output_dir, contract, bench)
+
+    stale_path = Path.join(output_dir, "research/findings.json")
+    File.mkdir_p!(Path.dirname(stale_path))
+    File.write!(stale_path, Jason.encode!(%{status: "complete", thesis: "stale"}))
+
+    assert RunStore.result_envelope(output_dir).research_findings == nil
+  end
+
+  test "result_envelope ignores corrupt recorded research findings without crashing" do
+    output_dir = Path.join(unique_tmp_dir("thinktank-run-store-corrupt-findings"), "run")
+
+    contract = %RunContract{
+      bench_id: "research/default",
+      workspace_root: File.cwd!(),
+      input: %{input_text: "hello"},
+      artifact_dir: output_dir,
+      adapter_context: %{}
+    }
+
+    bench = %BenchSpec{id: "research/default", description: "Demo", agents: ["systems"]}
+
+    RunStore.init_run(output_dir, contract, bench)
+    RunStore.write_json_artifact(output_dir, "research-findings", "research/findings.json", %{})
+    File.write!(Path.join(output_dir, "research/findings.json"), "not json")
+
+    assert RunStore.result_envelope(output_dir).research_findings == nil
   end
 
   test "aggregates usd cost totals and per-model usage into the result envelope" do
@@ -278,6 +334,8 @@ defmodule Thinktank.RunStoreTest do
     assert File.read!(Path.join(output_dir, "summary.md")) =~ "Partial Result"
     assert File.read!(Path.join(output_dir, "summary.md")) =~ "partial finding"
     assert File.exists?(Path.join(output_dir, "synthesis.md"))
+
+    refute File.exists?(Path.join(output_dir, "research/findings.json"))
   end
 
   test "initializes trace artifacts and updates trace summary on completion" do


### PR DESCRIPTION
## Summary
- Add a schema-first `research/findings.json` artifact for research synthesis output.
- Expose validated structured findings through the run result envelope as `research_findings`.
- Render `synthesis.md` from validated findings and persist typed failure/partial statuses for invalid JSON, schema violations, synth failures, and no-synthesis runs.
- Close backlog item 023 and mark previously shipped backlog item 008 done.

## Verification
- `./scripts/with-colima.sh dagger call check` -> 13 passed, 0 failed
- `mix test` -> 239 tests, 0 failures (3 excluded)
- Dagger e2e smoke -> 2 tests, 0 failures


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Research benches now generate structured findings in JSON format (`research/findings.json`), including thesis, findings, evidence, and confidence levels.
  * Research findings are included in run results.

* **Improvements**
  * Enhanced validation and error reporting for research synthesis outputs with clearer failure categorization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->