### PR TITLE
chore(backlog): close 023 in the index

### DIFF
--- a/backlog.d/README.md
+++ b/backlog.d/README.md
@@ -20,7 +20,6 @@ Status conventions:
 
 | # | Title | Priority | Estimate |
 |---|-------|----------|----------|
-| [023](023-add-structured-research-findings-contract.md) | Add Structured Research Findings Contract | high | M |
 | [024](024-add-first-class-focused-review-benches.md) | Add First-Class Focused Review Benches | medium | M |
 | [018](018-centralize-gate-policy-sources-and-remove-overlap.md) | Centralize Gate Policy Sources And Remove Overlap | medium | M |
 | [020](020-capability-aware-benches-validate.md) | Capability-Aware Benches Validate | medium | M |
@@ -50,6 +49,7 @@ See [done/](done/) for full write-ups including "What Was Built" notes.
 | [017](done/017-reduce-review-control-plane-to-structured-contracts.md) | Reduce Review Control Plane To Structured Contracts |
 | [019](done/019-fix-default-review-bench-guard-agent-incompatibility.md) | Fix Default Review Bench Guard Agent Incompatibility |
 | [022](done/022-add-run-inspection-and-explicit-run-state-commands.md) | Add Run Inspection And Explicit Run State Commands |
+| [023](done/023-add-structured-research-findings-contract.md) | Add Structured Research Findings Contract |
 
 ## Workflow
 


### PR DESCRIPTION
## Summary
- remove 023 from the active backlog queue
- add 023 to the done index to match the already-merged ticket

## Testing
- scripts/ci/backlog-state-gate.sh
- ./scripts/with-colima.sh dagger call check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated backlog tracking to reflect completion of the Structured Research Findings Contract feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->