### PR TITLE
chore(skills): install ship skill

### DIFF
--- a/.agent/skills/ship/SKILL.md
+++ b/.agent/skills/ship/SKILL.md
@@ -1,0 +1,298 @@
+---
+name: ship
+description: |
+  Final mile. Take a merge-ready branch to shipped: squash-merge, archive
+  the backlog ticket(s), sync touched docs, run /reflect, and apply its
+  outputs. Assumes /settle already left the branch merge-ready — ship does
+  not run CI, code-review, or refactor itself. If those are not done, run
+  /settle first.
+  Use when: "ship it", "merge and close out", "final mile", "land and
+  reflect", "finish this ticket".
+  Trigger: /ship.
+argument-hint: "[branch-or-pr]"
+---
+
+# /ship
+
+The final mile. Branch is merge-ready; `/ship` lands it, archives the
+ticket(s), syncs docs, runs `/reflect`, and threads reflect's outputs back
+into the repo. One command from "green" to "shipped and learned from."
+
+## Repo-specific (thinktank)
+
+Primary branch is `master`. Completed backlog items live under
+`backlog.d/done/`, not `backlog.d/_done/`. ThinkTank feature branches are
+normally named `feat/<id>`, `fix/<id>`, `chore/<id>`, `refactor/<id>`,
+`docs/<id>`, `test/<id>`, or `perf/<id>`; allow an optional `-slug`
+suffix, but the numeric capture is still the primary backlog ID. Release
+Please owns version bumps and release PRs. `/reflect cycle` may propose
+harness edits, but those must land on `reflect/<cycle-id>`, never on
+`master`.
+
+This repo does not ship `scripts/lib/backlog.sh` or `scripts/lib/verdicts.sh`.
+Archive tickets with direct `git mv`, and treat existing backlog trailers as
+optional metadata to preserve, not a required local helper contract.
+
+## Stance
+
+1. Act, do not propose. `/ship` has authority within its domain: archive,
+   merge, pull, reflect, apply.
+2. Pre-merge prep belongs on the shipping branch. Archive moves and doc
+   syncs happen before the squash so the merge records one clean closure
+   event.
+3. `/ship` is not `/settle`. If merge-readiness is in doubt, refuse and
+   route the operator back to `/settle`.
+4. Reflect's harness edits never touch `master`. They go to
+   `reflect/<cycle-id>` for human review.
+
+## Prerequisites
+
+Assert these first; refuse on any miss.
+
+- On a feature branch, not `master`.
+- Branch name matches
+  `^(feat|fix|chore|refactor|docs|test|perf)/(\\d+)(-.+)?$`.
+- Working tree clean.
+- If a PR exists, `gh pr view --json mergeable,mergeStateStatus` reports
+  mergeable and `gh pr checks` is green.
+- `/settle` has already left the branch merge-ready. In git-native mode,
+  require a recent clean `./scripts/with-colima.sh dagger call check` on
+  the current `HEAD`.
+- The primary backlog ID exists as a top-level `backlog.d/<id>-*.md` file,
+  or the branch commits contain explicit `Closes-backlog:` /
+  `Ships-backlog:` trailers. Shipping with no backlog association is a
+  refuse condition.
+
+## Process
+
+### 1. Extract backlog IDs
+
+Primary ID comes from the branch regex capture. Then scan branch commits for
+trailers:
+
+```sh
+git log --format=%B master..HEAD \
+  | git interpret-trailers --parse --no-divider
+```
+
+Collect:
+
+- Closing set: primary ID plus every `Closes-backlog:` and
+  `Ships-backlog:` value.
+- Reference set: every `Refs-backlog:` value.
+
+If the repo has no trailer practice on the branch, that is fine. Close the
+primary ID and preserve any trailers only when they already exist.
+
+### 2. Archive backlog files on the shipping branch
+
+For each ID in the closing set, locate a top-level backlog file:
+
+```sh
+file="$(rg --files backlog.d | rg "^backlog\\.d/${id}-.*\\.md$" | head -n1)"
+```
+
+If `file` exists, move it:
+
+```sh
+git mv "$file" backlog.d/done/
+```
+
+Rules:
+
+- Already archived in `backlog.d/done/` is fine; skip silently.
+- Missing file is acceptable only when the ID came from trailers or the
+  ticket was closure-only. Note it in the final report.
+- If the primary ID has no file and the branch has no closing trailers,
+  refuse.
+
+### 3. Sync touched docs
+
+Inspect the diff:
+
+```sh
+git diff master..HEAD --name-only
+```
+
+If existing docs were made stale by the shipped change, update them on the
+shipping branch before merge. Do not invent new docs just to satisfy the
+step. If no obvious docs need syncing, note that and continue.
+
+### 4. Create the archive commit on the feature branch
+
+If archiving or doc sync produced changes, commit them as one focused
+closure commit:
+
+```sh
+git commit -m "chore(backlog): archive shipped tickets"
+```
+
+If branch commits already carry backlog trailers, preserve them on this
+commit with `git interpret-trailers --if-exists addIfDifferent`. Do not
+hand-format trailer blocks.
+
+### 5. Squash-merge
+
+GitHub mode is preferred when `gh pr view` succeeds for the branch.
+
+If backlog trailers exist on the branch, pass them explicitly in the squash
+body so GitHub does not drop them:
+
+```sh
+body="$(git log --format=%B master..HEAD \
+  | git interpret-trailers --parse --no-divider \
+  | rg '^(Closes-backlog|Ships-backlog|Refs-backlog):' \
+  | sort -u)"
+gh pr merge --squash --body "$body"
+```
+
+If there are no trailers, merge with the repo's normal squash subject/body
+convention.
+
+Git-native fallback:
+
+```sh
+git checkout master
+git merge --squash <branch>
+git commit
+```
+
+### 6. Pull `master` and verify closure
+
+After merge:
+
+```sh
+git checkout master
+git pull --ff-only
+```
+
+Verify:
+
+- Every closable backlog file now lives under `backlog.d/done/`.
+- If trailers were present before merge, they survived into the squash
+  commit.
+
+If trailer preservation failed, stop and surface it. Do not pretend the
+closeout is complete.
+
+### 7. Invoke `/reflect cycle`
+
+Run `/reflect cycle` scoped to the shipped work and pass:
+
+- Pre-merge branch name
+- Merged `master` SHA
+- Closing backlog IDs
+- Reference-only backlog IDs
+
+Capture:
+
+- Backlog mutations
+- Harness-tuning proposals
+- Retro notes and coaching output
+
+### 8. Apply reflect's backlog mutations on `master`
+
+If reflect proposes new tickets or edits to open tickets, apply them on
+`master` and commit:
+
+```text
+chore(backlog): apply reflect outputs from shipping <primary-id>
+```
+
+If reflect proposes no backlog mutations, skip this step.
+
+### 9. Apply harness outputs to `reflect/<cycle-id>`
+
+Reflect's harness edits never land on `master`. Create or update the branch
+named by the reflect cycle contract:
+
+```sh
+git checkout -B reflect/<cycle-id> master
+```
+
+Apply only the harness changes there, commit them, push the branch, then
+return to `master`.
+
+### 10. Final report
+
+Emit one plain-text block covering:
+
+- Merged SHA on `master` and PR number if GitHub mode
+- Closed backlog IDs
+- Reference-only backlog IDs
+- Docs touched, or `none required`
+- Reflect outputs by category: backlog mutations, harness proposals, retro
+- Harness branch name
+- Residual risks or follow-ups
+
+## Refuse Conditions
+
+Stop and surface the reason instead of shipping when:
+
+- Branch name does not yield a primary backlog ID.
+- Working tree is dirty.
+- Current branch is `master`.
+- PR is conflicted, blocked, or has failing checks.
+- `/settle` clearly has not been run yet.
+- Primary backlog ID has no top-level backlog file and the branch carries no
+  closing trailers.
+- Rebase, merge, or cherry-pick is already in progress.
+- The branch was already shipped and deleted upstream.
+
+## Trailer Conventions
+
+When trailers exist, preserve these keys exactly:
+
+- `Closes-backlog: <id>`
+- `Ships-backlog: <id>`
+- `Refs-backlog: <id>`
+
+IDs are bare numeric strings such as `023`. Inject trailers with
+`git interpret-trailers`, never by hand.
+
+## GitHub Mode vs Git-Native Mode
+
+| Mode | Detection | Merge command |
+|---|---|---|
+| GitHub | `gh` available and `gh pr view` succeeds | `gh pr merge --squash` |
+| Git-native | no PR, no `gh`, or no GitHub remote | `git merge --squash <branch>` |
+
+GitHub mode is preferred because the PR timeline records the merge.
+
+## Interactions
+
+- Upstream: `/settle` leaves the branch merge-ready.
+- Invokes: `/reflect cycle`.
+- Invoked by: `/flywheel` as the landing and reflection stage.
+- Complements `/yeet`: `/yeet` ships the worktree to the remote; `/ship`
+  ships the settled branch to `master`.
+
+## Gotchas
+
+- ThinkTank archives to `backlog.d/done/`, not `_done/`.
+- ThinkTank branch names are usually `feat/023`, not `feat/023-slug`.
+- This repo does not provide backlog or verdict helper scripts. Use direct
+  `git mv` and explicit PR or CI checks.
+- GitHub's default squash body can drop trailers. Pass an explicit body when
+  trailers matter.
+- Archive before merge, not after. Splitting closure across two commits makes
+  backlog history harder to trust.
+- Reflect harness edits belong on `reflect/<cycle-id>`, never on `master`.
+- Re-running `/ship` on an already merged branch should exit early, not try
+  to archive or reflect twice.
+
+## Output
+
+```text
+/ship complete
+
+Merged:     <sha> on master (PR #<n>)
+Closed:     023
+Referenced: none
+Docs:       AGENTS.md (synced)
+Reflect:    1 backlog mutation applied, 2 harness proposals on
+            reflect/<cycle-id>, retro captured
+Residual:   none
+```
+
+On refuse, emit the reason and the action needed to re-enable shipping.

--- a/.claude/skills/ship
+++ b/.claude/skills/ship
@@ -1,0 +1,1 @@
+../../.agent/skills/ship

--- a/.codex/skills/ship
+++ b/.codex/skills/ship
@@ -1,0 +1,1 @@
+../../.agent/skills/ship

--- a/.pi/skills/ship
+++ b/.pi/skills/ship
@@ -1,0 +1,1 @@
+../../.agent/skills/ship

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,7 @@ Shared spellbook-tailored skills installed here:
 | `refactor` | Simplify review/runtime/control-plane hotspots without introducing new orchestration layers |
 | `reflect` | Post-work codification and harness hardening |
 | `research` | Repo-aware multi-source research, not one-source lookup |
+| `ship` | Final-mile landing for a settled branch: archive shipped tickets under `backlog.d/done/`, merge to `master`, then run `/reflect cycle` with harness edits on `reflect/<cycle-id>` |
 | `settle` | Land a clean branch to `master` while respecting hooks, Conventional Commits, and Release Please |
 | `shape` | Turn thin-launcher-safe ideas into context packets with executable oracles |
 | `yeet` | Commit and push intentionally without `--no-verify` or stray workspace junk |

--- a/backlog.d/025-add-ship-skill.md
+++ b/backlog.d/025-add-ship-skill.md
@@ -1,0 +1,34 @@
+# Add Ship Skill
+
+Priority: low
+Status: in-progress
+Estimate: S
+
+## Goal
+ThinkTank can use a repo-local `ship` skill for final-mile branch landing without depending on spellbook-global files that do not exist in this repo.
+
+## Non-Goals
+- Replacing `/settle` or `/yeet`
+- Adding new shell helper libraries under `scripts/lib/`
+- Changing release-please or merge policy
+
+## Constraints / Invariants
+- The installed skill lives in `.agent/skills/ship/` and is bridged into `.claude/skills/`, `.codex/skills/`, and `.pi/skills/`
+- The skill body must match ThinkTank's actual conventions: `backlog.d/done/`, `master`, and `reflect/<cycle-id>`
+- The install must not rely on missing repo-local helpers such as `scripts/lib/backlog.sh` or `scripts/lib/verdicts.sh`
+
+## Repo Anchors
+- `.agent/skills/`
+- `.claude/skills/`
+- `.codex/skills/`
+- `.pi/skills/`
+- `AGENTS.md`
+
+## Oracle
+- [x] `.agent/skills/ship/SKILL.md` exists with ThinkTank-specific guidance
+- [x] `.claude/skills/ship`, `.codex/skills/ship`, and `.pi/skills/ship` resolve to the shared skill
+- [x] `AGENTS.md` lists `ship` in the skill index
+- [x] `scripts/ci/harness-agent-gate.sh` passes after the install
+
+## Notes
+Spellbook already has a global `ship` skill, but the upstream body assumes backlog helper scripts and archive paths that this repo does not use. The repo-local install should preserve the intent while adapting the operational details to ThinkTank.

--- a/backlog.d/README.md
+++ b/backlog.d/README.md
@@ -15,12 +15,12 @@ Status conventions:
 | # | Title | Priority | Estimate |
 |---|-------|----------|----------|
 | [008](008-enforce-command-plane-architecture-gates.md) | Enforce Command-Plane Architecture Gates | medium | L |
+| [025](025-add-ship-skill.md) | Add Ship Skill | low | S |
 
 ## Active (ready to pick)
 
 | # | Title | Priority | Estimate |
 |---|-------|----------|----------|
-| [023](023-add-structured-research-findings-contract.md) | Add Structured Research Findings Contract | high | M |
 | [024](024-add-first-class-focused-review-benches.md) | Add First-Class Focused Review Benches | medium | M |
 | [018](018-centralize-gate-policy-sources-and-remove-overlap.md) | Centralize Gate Policy Sources And Remove Overlap | medium | M |
 | [020](020-capability-aware-benches-validate.md) | Capability-Aware Benches Validate | medium | M |
@@ -50,6 +50,7 @@ See [done/](done/) for full write-ups including "What Was Built" notes.
 | [017](done/017-reduce-review-control-plane-to-structured-contracts.md) | Reduce Review Control Plane To Structured Contracts |
 | [019](done/019-fix-default-review-bench-guard-agent-incompatibility.md) | Fix Default Review Bench Guard Agent Incompatibility |
 | [022](done/022-add-run-inspection-and-explicit-run-state-commands.md) | Add Run Inspection And Explicit Run State Commands |
+| [023](done/023-add-structured-research-findings-contract.md) | Add Structured Research Findings Contract |
 
 ## Workflow
 

--- a/backlog.d/README.md
+++ b/backlog.d/README.md
@@ -15,7 +15,6 @@ Status conventions:
 | # | Title | Priority | Estimate |
 |---|-------|----------|----------|
 | [008](008-enforce-command-plane-architecture-gates.md) | Enforce Command-Plane Architecture Gates | medium | L |
-| [025](025-add-ship-skill.md) | Add Ship Skill | low | S |
 
 ## Active (ready to pick)
 
@@ -51,6 +50,7 @@ See [done/](done/) for full write-ups including "What Was Built" notes.
 | [019](done/019-fix-default-review-bench-guard-agent-incompatibility.md) | Fix Default Review Bench Guard Agent Incompatibility |
 | [022](done/022-add-run-inspection-and-explicit-run-state-commands.md) | Add Run Inspection And Explicit Run State Commands |
 | [023](done/023-add-structured-research-findings-contract.md) | Add Structured Research Findings Contract |
+| [025](done/025-add-ship-skill.md) | Add Ship Skill |
 
 ## Workflow
 

--- a/backlog.d/done/025-add-ship-skill.md
+++ b/backlog.d/done/025-add-ship-skill.md
@@ -1,7 +1,7 @@
 # Add Ship Skill
 
 Priority: low
-Status: in-progress
+Status: done
 Estimate: S
 
 ## Goal
@@ -29,6 +29,11 @@ ThinkTank can use a repo-local `ship` skill for final-mile branch landing withou
 - [x] `.claude/skills/ship`, `.codex/skills/ship`, and `.pi/skills/ship` resolve to the shared skill
 - [x] `AGENTS.md` lists `ship` in the skill index
 - [x] `scripts/ci/harness-agent-gate.sh` passes after the install
+
+## What Was Built
+- Installed a repo-local `ship` skill under `.agent/skills/ship/` with ThinkTank-specific final-mile instructions instead of the spellbook-global helper assumptions.
+- Bridged the shared skill into `.claude/skills/ship`, `.codex/skills/ship`, and `.pi/skills/ship` so all three harnesses resolve the same body.
+- Added `ship` to the repo skill index in `AGENTS.md` and kept the backlog index aligned with the shipped state.
 
 ## Notes
 Spellbook already has a global `ship` skill, but the upstream body assumes backlog helper scripts and archive paths that this repo does not use. The repo-local install should preserve the intent while adapting the operational details to ThinkTank.


### PR DESCRIPTION
## Summary
- install a repo-local `ship` skill tailored to ThinkTank
- bridge the skill into Claude, Codex, and Pi
- archive backlog item 025 as shipped

## Testing
- ./scripts/with-colima.sh dagger call check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/ship` command to automate branch finalization workflow, including merge-readiness validation, backlog item archival, documentation synchronization, squash-merge to main branch, and automated reflect cycle trigger.

* **Documentation**
  * Updated command index and backlog tracker to document `/ship` skill availability and operational requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->